### PR TITLE
fix: ensure email-validator is installed with pydantic[email]

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "app"}]
 python = "^3.11"
 fastapi = "^0.109.0"
 uvicorn = {extras = ["standard"], version = "^0.27.0"}
-pydantic = "^2.5.3"
+pydantic = {extras = ["email"], version = "^2.5.3"}
 pydantic-settings = "^2.1.0"
 sqlalchemy = "^2.0.25"
 alembic = "^1.13.1"


### PR DESCRIPTION
Changed pydantic dependency to use extras=["email"] which automatically installs and configures email-validator correctly.

This fixes the ImportError on Render deployment where email-validator was not being installed even though it was listed as a separate dependency.

Fixes: ImportError: email-validator is not installed