### PR TITLE
fix: JWT account_type serialization and authorization case sensitivity

### DIFF
--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -108,7 +108,7 @@ def get_current_user_account_type(credentials: HTTPAuthorizationCredentials = De
 def require_any_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
     """Require any valid user account type and return user ID."""
     token_data = verify_token(credentials.credentials)
-    check_permissions(token_data.account_type, ["PROFESSIONAL", "CLIENT"])
+    check_permissions(token_data.account_type, ["professional", "client"])
     return token_data.user_id
 
 

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -27,7 +27,7 @@ class AuthService:
         user = self.user_repository.create(user_data)
 
         # Create tokens
-        token_data = {"sub": str(user.id), "email": user.email, "account_type": user.account_type}
+        token_data = {"sub": str(user.id), "email": user.email, "account_type": user.account_type.value if hasattr(user.account_type, 'value') else user.account_type}
         access_token = create_access_token(data=token_data)
         refresh_token = create_refresh_token(data=token_data)
 
@@ -47,7 +47,7 @@ class AuthService:
             raise AuthenticationError("Account is disabled")
 
         # Create tokens
-        token_data = {"sub": str(user.id), "email": user.email, "account_type": user.account_type}
+        token_data = {"sub": str(user.id), "email": user.email, "account_type": user.account_type.value if hasattr(user.account_type, 'value') else user.account_type}
         access_token = create_access_token(data=token_data)
         refresh_token = create_refresh_token(data=token_data)
 
@@ -73,7 +73,7 @@ class AuthService:
             raise AuthenticationError("Account is disabled")
 
         # Create new tokens
-        new_token_data = {"sub": str(user.id), "email": user.email, "account_type": user.account_type}
+        new_token_data = {"sub": str(user.id), "email": user.email, "account_type": user.account_type.value if hasattr(user.account_type, 'value') else user.account_type}
         access_token = create_access_token(data=new_token_data)
         new_refresh_token = create_refresh_token(data=new_token_data)
 


### PR DESCRIPTION
- Serialize account_type enum to string value in JWT tokens
- Fix case sensitivity in require_any_user permission check (PROFESSIONAL/CLIENT -> professional/client)
- Prevents 'Invalid user ID format' error after registration