### PR TITLE
feat: implement Phase 2 - Account Type Restructure (CLIENT → COMPANY)

### DIFF
--- a/backend/alembic/versions/31eeee5d1792_update_account_type_client_to_company.py
+++ b/backend/alembic/versions/31eeee5d1792_update_account_type_client_to_company.py
@@ -1,0 +1,28 @@
+"""update_account_type_client_to_company
+
+Revision ID: 31eeee5d1792
+Revises: 0001
+Create Date: 2025-10-28 10:49:40.662631
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '31eeee5d1792'
+down_revision = '0001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Update account_type from 'client' to 'company' for existing users."""
+    # Update all users with account_type='client' to 'company'
+    op.execute("UPDATE users SET account_type = 'company' WHERE account_type = 'client'")
+
+
+def downgrade() -> None:
+    """Rollback: Update account_type from 'company' back to 'client'."""
+    # Rollback: Update all users with account_type='company' to 'client'
+    op.execute("UPDATE users SET account_type = 'client' WHERE account_type = 'company'") 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -108,7 +108,7 @@ def get_current_user_account_type(credentials: HTTPAuthorizationCredentials = De
 def require_any_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
     """Require any valid user account type and return user ID."""
     token_data = verify_token(credentials.credentials)
-    check_permissions(token_data.account_type, ["professional", "client"])
+    check_permissions(token_data.account_type, ["professional", "company"])
     return token_data.user_id
 
 
@@ -123,11 +123,11 @@ def require_professional(user_account_type: str) -> None:
     check_permissions(user_account_type, ["professional"])
 
 
-def require_client(user_account_type: str) -> None:
-    """Require client account type."""
-    check_permissions(user_account_type, ["client"])
+def require_company(user_account_type: str) -> None:
+    """Require company account type."""
+    check_permissions(user_account_type, ["company"])
 
 
 def require_any_user(user_account_type: str) -> None:
     """Require any valid user account type."""
-    check_permissions(user_account_type, ["professional", "client"]) 
+    check_permissions(user_account_type, ["professional", "company"]) 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -10,9 +10,9 @@ from app.models.base import BaseModel
 
 class AccountType(str, Enum):
     """Account type enumeration."""
-    
+
     PROFESSIONAL = "professional"
-    CLIENT = "client"
+    COMPANY = "company"
 
 
 class User(BaseModel):
@@ -24,7 +24,7 @@ class User(BaseModel):
     password_hash = Column(String(255), nullable=False)
     full_name = Column(String(255), nullable=False)
     phone = Column(String(20), nullable=True)
-    account_type = Column(String(20), nullable=False, default=AccountType.CLIENT)
+    account_type = Column(String(20), nullable=False, default=AccountType.COMPANY)
     active = Column(Boolean, default=True, nullable=False)
     
     # Relationships

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -16,9 +16,9 @@ const HomePage: React.FC = () => {
               Bem-vindo, {user.full_name}!
             </h1>
             <p className="text-xl text-gray-600 mb-8">
-              {user.account_type === 'client'
+              {user.account_type === 'company'
                 ? 'Encontre os melhores profissionais para seus projetos'
-                : 'Conecte-se com clientes e projetos incríveis'
+                : 'Conecte-se com empresas e projetos incríveis'
               }
             </p>
           </div>
@@ -52,7 +52,7 @@ const HomePage: React.FC = () => {
                 </div>
                 <h3 className="text-lg font-semibold text-gray-900">Projetos</h3>
                 <p className="text-sm text-gray-600">
-                  {user.account_type === 'client' ? 'Gerencie seus projetos' : 'Explore oportunidades'}
+                  {user.account_type === 'company' ? 'Gerencie seus projetos' : 'Explore oportunidades'}
                 </p>
               </div>
             </Link>
@@ -125,13 +125,13 @@ const HomePage: React.FC = () => {
                 <div className="text-center">
                   <div className="text-2xl font-bold text-blue-600">0</div>
                   <div className="text-sm text-gray-600">
-                    {user.account_type === 'client' ? 'Projetos' : 'Propostas'}
+                    {user.account_type === 'company' ? 'Projetos' : 'Propostas'}
                   </div>
                 </div>
                 <div className="text-center">
                   <div className="text-2xl font-bold text-green-600">0</div>
                   <div className="text-sm text-gray-600">
-                    {user.account_type === 'client' ? 'Propostas' : 'Projetos'}
+                    {user.account_type === 'company' ? 'Propostas' : 'Projetos'}
                   </div>
                 </div>
               </div>
@@ -183,10 +183,10 @@ const HomePage: React.FC = () => {
                   <p className="text-sm text-gray-500 text-center mb-4">Ou experimente com uma conta demo:</p>
                   <div className="flex flex-col sm:flex-row gap-3 justify-center lg:justify-start">
                     <button
-                      onClick={() => loginDemo('client')}
+                      onClick={() => loginDemo('company')}
                       className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 border border-gray-300 rounded-md hover:bg-gray-200 transition-colors"
                     >
-                      🏢 Demo Cliente
+                      🏢 Demo Empresa
                     </button>
                     <button
                       onClick={() => loginDemo('professional')}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -9,7 +9,7 @@ const RegisterPage = () => {
     email: '',
     password: '',
     fullName: '',
-    accountType: 'client',
+    accountType: 'company',
   })
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState('')
@@ -27,7 +27,7 @@ const RegisterPage = () => {
         email: formData.email,
         password: formData.password,
         full_name: formData.fullName,
-        account_type: formData.accountType as 'client' | 'professional',
+        account_type: formData.accountType as 'company' | 'professional',
       })
 
       // Store tokens
@@ -134,7 +134,7 @@ const RegisterPage = () => {
                 value={formData.accountType}
                 onChange={handleChange}
               >
-                <option value="client">Client</option>
+                <option value="company">Company</option>
                 <option value="professional">Professional</option>
               </select>
             </div>

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -4,7 +4,7 @@ export interface RegisterData {
   email: string;
   password: string;
   full_name: string;
-  account_type: 'client' | 'professional';
+  account_type: 'company' | 'professional';
 }
 
 export interface LoginData {
@@ -22,7 +22,7 @@ export interface UserData {
   id: string;
   email: string;
   full_name: string;
-  account_type: 'client' | 'professional';
+  account_type: 'company' | 'professional';
   is_active: boolean;
   created_at: string;
 }

--- a/frontend/src/stores/authStore.ts
+++ b/frontend/src/stores/authStore.ts
@@ -5,7 +5,7 @@ interface User {
   id: string
   email: string
   full_name: string
-  account_type: 'professional' | 'client'
+  account_type: 'professional' | 'company'
 }
 
 interface AuthState {
@@ -15,7 +15,7 @@ interface AuthState {
   login: (user: User, token: string) => void
   logout: () => void
   updateUser: (user: User) => void
-  loginDemo: (accountType: 'client' | 'professional') => void
+  loginDemo: (accountType: 'company' | 'professional') => void
 }
 
 export const useAuthStore = create<AuthState>()(
@@ -30,11 +30,11 @@ export const useAuthStore = create<AuthState>()(
         set({ user: null, token: null, isAuthenticated: false }),
       updateUser: (user: User) =>
         set({ user }),
-      loginDemo: (accountType: 'client' | 'professional') => {
+      loginDemo: (accountType: 'company' | 'professional') => {
         const demoUser: User = {
           id: 'demo-' + accountType,
-          email: accountType === 'client' ? 'cliente@demo.com' : 'profissional@demo.com',
-          full_name: accountType === 'client' ? 'Cliente Demo' : 'Profissional Demo',
+          email: accountType === 'company' ? 'empresa@demo.com' : 'profissional@demo.com',
+          full_name: accountType === 'company' ? 'Empresa Demo' : 'Profissional Demo',
           account_type: accountType
         };
         set({ user: demoUser, token: 'demo-token', isAuthenticated: true });


### PR DESCRIPTION
Rename account type from 'client' to 'company' throughout the codebase to better reflect that companies publish job openings.

## Backend Changes:
- Updated AccountType enum: CLIENT → COMPANY
- Updated default account_type in User model
- Renamed require_client() → require_company() in security.py
- Updated permission checks to use 'company' instead of 'client'
- Created migration to update existing user records in database

## Frontend Changes:
- Updated type definitions in authStore.ts and authService.ts
- Updated RegisterPage default accountType and form labels
- Updated HomePage text and conditional rendering
- Changed demo button from "Demo Cliente" to "Demo Empresa"
- Updated all 'client' references to 'company' in UI text

## Database Migration:
- Migration file: 31eeee5d1792_update_account_type_client_to_company.py
- Updates existing users with account_type='client' to 'company'
- Includes rollback support
