### PR TITLE
fix: correct migration to handle account_type as String instead of ENUM

### DIFF
--- a/backend/alembic/versions/55b914fd2168_add_admin_role_to_account_type.py
+++ b/backend/alembic/versions/55b914fd2168_add_admin_role_to_account_type.py
@@ -16,12 +16,12 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Add 'admin' value to the accounttype enum in PostgreSQL
-    op.execute("ALTER TYPE accounttype ADD VALUE IF NOT EXISTS 'admin'")
+    # No database schema changes needed.
+    # The account_type column is String(20), not a PostgreSQL ENUM.
+    # The 'admin' value is validated at the application level via Python's AccountType enum.
+    pass
 
 
 def downgrade() -> None:
-    # Note: PostgreSQL does not support removing values from enums directly
-    # This would require more complex migration (recreate enum, update column, etc.)
-    # For safety, we'll just warn that this cannot be automatically downgraded
+    # No database schema changes were made in upgrade, so no downgrade needed.
     pass


### PR DESCRIPTION
The migration was attempting to execute ALTER TYPE on a non-existent PostgreSQL ENUM. The account_type column is defined as String(20) in the User model, not as a native PostgreSQL ENUM type. The validation is done at the application level via Python's AccountType enum.

This fix removes the incorrect ALTER TYPE statement and replaces it with a pass, since no database schema changes are needed.

Fixes deployment error:
- psycopg2.errors.UndefinedObject: type "accounttype" does not exist
