### PR TITLE
fix: merge alembic heads to resolve migration conflict

### DIFF
--- a/backend/alembic/versions/57fb0d64d5d_merge_heads.py
+++ b/backend/alembic/versions/57fb0d64d5d_merge_heads.py
@@ -1,0 +1,25 @@
+"""merge_heads
+
+Revision ID: 57fb0d64d5d
+Revises: 0e442c50bf8, dfc933efdaae
+Create Date: 2025-10-29 22:45:00.000000
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "57fb0d64d5d"
+down_revision = ("0e442c50bf8", "dfc933efdaae")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge migration - no changes needed."""
+    pass
+
+
+def downgrade() -> None:
+    """Merge migration - no changes needed."""
+    pass


### PR DESCRIPTION
Created merge migration to resolve multiple head revisions issue. The migration merges two parallel branches:
- 0e442c50bf8 (add_client_profile_fields_and_client_links)
- dfc933efdaae (add_requirements_field_to_projects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)