### PR TITLE
feat: add MindHire rebrand and enhance platform features

### DIFF
--- a/backend/tests/factories.py
+++ b/backend/tests/factories.py
@@ -1,0 +1,149 @@
+"""Factories for testing using factory_boy and faker."""
+
+import factory
+from factory.fuzzy import FuzzyChoice, FuzzyDecimal, FuzzyInteger
+from faker import Faker
+from sqlalchemy.orm import Session
+
+from app.models.client import ClientProfile
+from app.models.professional import ProfessionalProfile
+from app.models.project import Project, ProjectStatus
+from app.models.proposal import Proposal, ProposalStatus
+from app.models.review import Review, ReviewType
+from app.models.skill import Skill
+from app.models.user import AccountType, User
+
+fake = Faker()
+
+
+class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for User model."""
+
+    class Meta:
+        model = User
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    email = factory.LazyAttribute(lambda _: fake.email())
+    password_hash = factory.LazyAttribute(lambda _: fake.password())
+    full_name = factory.LazyAttribute(lambda _: fake.name())
+    phone = factory.LazyAttribute(lambda _: fake.phone_number())
+    account_type = FuzzyChoice([AccountType.PROFESSIONAL, AccountType.COMPANY])
+    active = True
+
+
+class ProfessionalProfileFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for ProfessionalProfile model."""
+
+    class Meta:
+        model = ProfessionalProfile
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    user = factory.SubFactory(UserFactory, account_type=AccountType.PROFESSIONAL)
+    title = factory.LazyAttribute(lambda _: fake.job())
+    description = factory.LazyAttribute(lambda _: fake.text(max_nb_chars=200))
+    bio = factory.LazyAttribute(lambda _: fake.text(max_nb_chars=300))
+    hourly_rate = FuzzyDecimal(50.0, 500.0, precision=2)
+    average_rating = None
+    total_reviews = 0
+
+
+class ClientProfileFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for ClientProfile model."""
+
+    class Meta:
+        model = ClientProfile
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    user = factory.SubFactory(UserFactory, account_type=AccountType.COMPANY)
+    company_name = factory.LazyAttribute(lambda _: fake.company())
+    business_sector = factory.LazyAttribute(lambda _: fake.bs())
+    description = factory.LazyAttribute(lambda _: fake.text(max_nb_chars=200))
+    bio = factory.LazyAttribute(lambda _: fake.text(max_nb_chars=300))
+    average_rating = None
+    total_reviews = 0
+
+
+class SkillFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for Skill model."""
+
+    class Meta:
+        model = Skill
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    name = factory.LazyAttribute(lambda _: fake.word())
+    category = factory.LazyAttribute(lambda _: fake.word())
+
+
+class ProjectFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for Project model."""
+
+    class Meta:
+        model = Project
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    client = factory.SubFactory(ClientProfileFactory)
+    title = factory.LazyAttribute(lambda _: fake.sentence(nb_words=6))
+    description = factory.LazyAttribute(lambda _: fake.text(max_nb_chars=500))
+    requirements = factory.LazyAttribute(
+        lambda _: {
+            "skills": [fake.word() for _ in range(3)],
+            "experience": f"{fake.random_int(1, 10)} years",
+        }
+    )
+    budget = FuzzyDecimal(1000.0, 50000.0, precision=2)
+    deadline = factory.LazyAttribute(lambda _: fake.future_date())
+    status = FuzzyChoice(
+        [ProjectStatus.OPEN, ProjectStatus.IN_PROGRESS, ProjectStatus.COMPLETED]
+    )
+    selected_professional_id = None
+
+
+class ProposalFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for Proposal model."""
+
+    class Meta:
+        model = Proposal
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    project = factory.SubFactory(ProjectFactory, status=ProjectStatus.OPEN)
+    professional = factory.SubFactory(ProfessionalProfileFactory)
+    proposed_amount = FuzzyDecimal(1000.0, 50000.0, precision=2)
+    estimated_days = FuzzyInteger(7, 90)
+    description = factory.LazyAttribute(lambda _: fake.text(max_nb_chars=500))
+    status = ProposalStatus.SUBMITTED
+    ai_score = None
+
+
+class ReviewFactory(factory.alchemy.SQLAlchemyModelFactory):
+    """Factory for Review model."""
+
+    class Meta:
+        model = Review
+        sqlalchemy_session = None
+        sqlalchemy_session_persistence = "commit"
+
+    project = factory.SubFactory(ProjectFactory, status=ProjectStatus.COMPLETED)
+    reviewer = factory.SubFactory(UserFactory)
+    reviewed = factory.SubFactory(UserFactory)
+    rating = FuzzyInteger(1, 5)
+    comment = factory.LazyAttribute(lambda _: fake.text(max_nb_chars=300))
+    review_type = FuzzyChoice(
+        [ReviewType.PROFESSIONAL_TO_CLIENT, ReviewType.CLIENT_TO_PROFESSIONAL]
+    )
+
+
+def set_sqlalchemy_session(session: Session):
+    """Set SQLAlchemy session for all factories."""
+    UserFactory._meta.sqlalchemy_session = session
+    ProfessionalProfileFactory._meta.sqlalchemy_session = session
+    ClientProfileFactory._meta.sqlalchemy_session = session
+    SkillFactory._meta.sqlalchemy_session = session
+    ProjectFactory._meta.sqlalchemy_session = session
+    ProposalFactory._meta.sqlalchemy_session = session
+    ReviewFactory._meta.sqlalchemy_session = session

--- a/backend/tests/test_proposals.py
+++ b/backend/tests/test_proposals.py
@@ -1,0 +1,183 @@
+"""Test proposal (application) endpoints and functionality."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database.base import Base
+from app.database.session import get_db
+from app.main import app
+from tests.factories import (
+    ProfessionalProfileFactory,
+    ProjectFactory,
+    ProposalFactory,
+    set_sqlalchemy_session,
+)
+
+# Create test database
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    """Override database dependency for testing."""
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture(scope="function")
+def db_session():
+    """Create a new database session for each test."""
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    set_sqlalchemy_session(session)
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def client():
+    """Create test client."""
+    return TestClient(app)
+
+
+def test_create_proposal_success(db_session, client: TestClient):
+    """Test successful proposal creation (professional applying to project)."""
+    # Create professional and open project
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(status="OPEN")
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/proposals/",
+        json={
+            "project_id": str(project.id),
+            "proposed_amount": 15000.00,
+            "estimated_days": 30,
+            "description": "I am the perfect fit for this project because...",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["project_id"] == str(project.id)
+    assert data["professional_id"] == str(professional.id)
+    assert data["proposed_amount"] == 15000.00
+    assert data["estimated_days"] == 30
+    assert data["status"] == "SUBMITTED"
+
+
+def test_create_proposal_duplicate(db_session, client: TestClient):
+    """Test that professional cannot apply to same project twice."""
+    proposal = ProposalFactory()
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/proposals/",
+        json={
+            "project_id": str(proposal.project_id),
+            "proposed_amount": 10000.00,
+            "estimated_days": 20,
+            "description": "Second application attempt",
+        },
+    )
+
+    # Should fail because professional already applied
+    assert response.status_code in [400, 409]
+
+
+def test_accept_proposal(db_session, client: TestClient):
+    """Test company accepting a proposal."""
+    proposal = ProposalFactory(status="SUBMITTED")
+    db_session.commit()
+
+    response = client.post(f"/api/v1/proposals/{proposal.id}/accept")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ACCEPTED"
+    assert data["id"] == str(proposal.id)
+
+
+def test_reject_proposal(db_session, client: TestClient):
+    """Test company rejecting a proposal."""
+    proposal = ProposalFactory(status="SUBMITTED")
+    db_session.commit()
+
+    response = client.post(f"/api/v1/proposals/{proposal.id}/reject")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "REJECTED"
+
+
+def test_list_proposals_by_project(db_session, client: TestClient):
+    """Test listing all proposals for a specific project."""
+    project = ProjectFactory(status="OPEN")
+    _ = [ProposalFactory(project=project) for _ in range(3)]
+    db_session.commit()
+
+    response = client.get(f"/api/v1/proposals/?project_id={project.id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 3
+
+
+def test_list_proposals_by_professional(db_session, client: TestClient):
+    """Test listing all proposals by a specific professional."""
+    professional = ProfessionalProfileFactory()
+    _ = [ProposalFactory(professional=professional) for _ in range(2)]
+    db_session.commit()
+
+    response = client.get(f"/api/v1/proposals/?professional_id={professional.id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 2
+
+
+def test_proposal_amount_validation(db_session, client: TestClient):
+    """Test that proposal amount must be positive."""
+    project = ProjectFactory(status="OPEN")
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/proposals/",
+        json={
+            "project_id": str(project.id),
+            "proposed_amount": -1000.00,  # Invalid negative amount
+            "description": "Test",
+        },
+    )
+
+    assert response.status_code == 422  # Validation error
+
+
+def test_proposal_only_for_open_projects(db_session, client: TestClient):
+    """Test that proposals can only be created for OPEN projects."""
+    project = ProjectFactory(status="COMPLETED")
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/proposals/",
+        json={
+            "project_id": str(project.id),
+            "proposed_amount": 10000.00,
+            "description": "Trying to apply to completed project",
+        },
+    )
+
+    # Should fail because project is not OPEN
+    assert response.status_code in [400, 403]

--- a/backend/tests/test_reviews.py
+++ b/backend/tests/test_reviews.py
@@ -1,0 +1,288 @@
+"""Test review (feedback) endpoints and functionality."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database.base import Base
+from app.database.session import get_db
+from app.main import app
+from tests.factories import (
+    ClientProfileFactory,
+    ProfessionalProfileFactory,
+    ProjectFactory,
+    ReviewFactory,
+    set_sqlalchemy_session,
+)
+
+# Create test database
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    """Override database dependency for testing."""
+    try:
+        db = TestingSessionLocal()
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture(scope="function")
+def db_session():
+    """Create a new database session for each test."""
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    set_sqlalchemy_session(session)
+    yield session
+    session.close()
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def client():
+    """Create test client."""
+    return TestClient(app)
+
+
+def test_create_review_client_to_professional(db_session, client: TestClient):
+    """Test company giving feedback to professional."""
+    # Create completed project with professional
+    client_profile = ClientProfileFactory()
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        client=client_profile,
+        selected_professional_id=professional.id,
+        status="COMPLETED",
+    )
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(professional.user_id),
+            "rating": 5,
+            "comment": "Excellent work! Very professional and delivered on time.",
+            "review_type": "client_to_professional",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["rating"] == 5
+    assert data["project_id"] == str(project.id)
+    assert data["reviewed_id"] == str(professional.user_id)
+    assert data["review_type"] == "client_to_professional"
+
+
+def test_create_review_professional_to_client(db_session, client: TestClient):
+    """Test professional giving feedback to company."""
+    client_profile = ClientProfileFactory()
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        client=client_profile,
+        selected_professional_id=professional.id,
+        status="COMPLETED",
+    )
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(client_profile.user_id),
+            "rating": 4,
+            "comment": "Great client, clear requirements and prompt payments.",
+            "review_type": "professional_to_client",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["rating"] == 4
+    assert data["review_type"] == "professional_to_client"
+
+
+def test_review_rating_validation(db_session, client: TestClient):
+    """Test that rating must be between 1 and 5."""
+    project = ProjectFactory(status="COMPLETED")
+    professional = ProfessionalProfileFactory()
+    db_session.commit()
+
+    # Test rating > 5
+    response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(professional.user_id),
+            "rating": 6,  # Invalid rating
+            "review_type": "client_to_professional",
+        },
+    )
+    assert response.status_code == 422
+
+    # Test rating < 1
+    response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(professional.user_id),
+            "rating": 0,  # Invalid rating
+            "review_type": "client_to_professional",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_review_comment_optional(db_session, client: TestClient):
+    """Test that comment is optional in reviews."""
+    client_profile = ClientProfileFactory()
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        client=client_profile,
+        selected_professional_id=professional.id,
+        status="COMPLETED",
+    )
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(professional.user_id),
+            "rating": 3,
+            "comment": None,  # Optional comment
+            "review_type": "client_to_professional",
+        },
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["rating"] == 3
+    assert data["comment"] is None
+
+
+def test_list_reviews_by_reviewed_user(db_session, client: TestClient):
+    """Test listing all reviews for a specific user (professional or company)."""
+    professional = ProfessionalProfileFactory()
+    # Create 3 reviews for this professional
+    _ = [ReviewFactory(reviewed=professional.user, rating=i) for i in range(3, 6)]
+    db_session.commit()
+
+    response = client.get(f"/api/v1/reviews/?reviewed_id={professional.user_id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 3
+
+
+def test_list_reviews_by_project(db_session, client: TestClient):
+    """Test listing all reviews for a specific project."""
+    project = ProjectFactory(status="COMPLETED")
+    _ = [ReviewFactory(project=project) for _ in range(2)]
+    db_session.commit()
+
+    response = client.get(f"/api/v1/reviews/?project_id={project.id}")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["items"]) == 2
+
+
+def test_get_average_rating_for_professional(db_session, client: TestClient):
+    """Test calculating average rating for a professional."""
+    professional = ProfessionalProfileFactory()
+    # Create reviews with ratings 3, 4, 5 (average = 4.0)
+    _ = [
+        ReviewFactory(reviewed=professional.user, rating=3),
+        ReviewFactory(reviewed=professional.user, rating=4),
+        ReviewFactory(reviewed=professional.user, rating=5),
+    ]
+    db_session.commit()
+
+    response = client.get(f"/api/v1/reviews/users/{professional.user_id}/rating")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "average_rating" in data
+    # Average should be 4.0
+    assert data["average_rating"] == pytest.approx(4.0, rel=0.1)
+
+
+def test_get_average_rating_for_company(db_session, client: TestClient):
+    """Test calculating average rating for a company."""
+    company = ClientProfileFactory()
+    # Create reviews with ratings 4, 5, 5 (average = 4.67)
+    _ = [
+        ReviewFactory(reviewed=company.user, rating=4),
+        ReviewFactory(reviewed=company.user, rating=5),
+        ReviewFactory(reviewed=company.user, rating=5),
+    ]
+    db_session.commit()
+
+    response = client.get(f"/api/v1/reviews/users/{company.user_id}/rating")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "average_rating" in data
+    # Average should be ~4.67
+    assert data["average_rating"] == pytest.approx(4.67, rel=0.1)
+
+
+def test_review_only_for_completed_projects(db_session, client: TestClient):
+    """Test that reviews can only be created for COMPLETED projects."""
+    project = ProjectFactory(status="IN_PROGRESS")
+    professional = ProfessionalProfileFactory()
+    db_session.commit()
+
+    response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(professional.user_id),
+            "rating": 5,
+            "review_type": "client_to_professional",
+        },
+    )
+
+    # Should fail because project is not COMPLETED
+    assert response.status_code in [400, 403]
+
+
+def test_update_review(db_session, client: TestClient):
+    """Test updating an existing review."""
+    review = ReviewFactory(rating=3, comment="Initial comment")
+    db_session.commit()
+
+    response = client.put(
+        f"/api/v1/reviews/{review.id}",
+        json={"rating": 5, "comment": "Updated comment - much better!"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["rating"] == 5
+    assert data["comment"] == "Updated comment - much better!"
+
+
+def test_delete_review(db_session, client: TestClient):
+    """Test deleting a review."""
+    review = ReviewFactory()
+    db_session.commit()
+
+    response = client.delete(f"/api/v1/reviews/{review.id}")
+
+    assert response.status_code == 204
+
+    # Verify review is deleted
+    response = client.get(f"/api/v1/reviews/{review.id}")
+    assert response.status_code == 404

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,9 @@ import DashboardPage from '@/pages/DashboardPage'
 import ProjectsPage from '@/pages/ProjectsPage'
 import ProjectDetailPage from '@/pages/ProjectDetailPage'
 import ProfessionalsPage from '@/pages/ProfessionalsPage'
+import ProfessionalDetailPage from '@/pages/ProfessionalDetailPage'
 import CompaniesPage from '@/pages/CompaniesPage'
+import CompanyDetailPage from '@/pages/CompanyDetailPage'
 import ProfilePage from '@/pages/ProfilePage'
 import UsersPage from '@/pages/UsersPage'
 import ProtectedRoute from '@/components/ProtectedRoute'
@@ -27,7 +29,9 @@ function App() {
           <Route path="projects" element={<ProjectsPage />} />
           <Route path="projects/:id" element={<ProjectDetailPage />} />
           <Route path="professionals" element={<ProfessionalsPage />} />
+          <Route path="professionals/:id" element={<ProfessionalDetailPage />} />
           <Route path="companies" element={<CompaniesPage />} />
+          <Route path="companies/:id" element={<CompanyDetailPage />} />
           <Route path="profile" element={<ProfilePage />} />
           <Route path="users" element={<UsersPage />} />
         </Route>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -3,7 +3,9 @@ const Footer = () => {
     <footer className="bg-white border-t border-gray-200">
       <div className="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
         <div className="text-center text-gray-500 text-sm">
-          <p>&copy; 2024 SaaS Platform. All rights reserved.</p>
+          <p className="font-semibold text-gray-700 mb-1">MindHire</p>
+          <p className="text-xs mb-2">Conectando talentos com inteligência</p>
+          <p>&copy; 2025 MindHire. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -9,8 +9,9 @@ const Header = () => {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           <div className="flex items-center">
-            <Link to="/" className="text-xl font-bold text-primary-600">
-              SaaS Platform
+            <Link to="/" className="flex flex-col">
+              <span className="text-xl font-bold text-primary-600">MindHire</span>
+              <span className="text-xs text-gray-500">Conectando talentos com inteligência</span>
             </Link>
           </div>
           

--- a/frontend/src/pages/CompaniesPage.tsx
+++ b/frontend/src/pages/CompaniesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { clientService, ClientProfile } from '@/services/clientService'
 
 const CompaniesPage = () => {
@@ -39,14 +40,24 @@ const CompaniesPage = () => {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {items.map((c) => (
-            <div key={c.id} className="card">
+            <Link key={c.id} to={`/companies/${c.id}`} className="card hover:shadow-lg transition-shadow">
               <div className="card-content">
-                <h3 className="text-lg font-semibold text-gray-900">{c.company_name || 'Company'}</h3>
+                <h3 className="text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors">
+                  {c.company_name || 'Company'}
+                </h3>
                 {c.business_sector && (
                   <p className="mt-2 text-gray-700 text-sm">Sector: {c.business_sector}</p>
                 )}
+                {c.description && (
+                  <p className="mt-2 text-gray-600 text-sm line-clamp-2">{c.description}</p>
+                )}
+                {c.average_rating != null && (
+                  <p className="mt-3 text-yellow-600 font-medium text-sm">
+                    ⭐ {Number(c.average_rating).toFixed(1)} ({c.total_reviews} reviews)
+                  </p>
+                )}
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/frontend/src/pages/CompanyDetailPage.tsx
+++ b/frontend/src/pages/CompanyDetailPage.tsx
@@ -7,7 +7,7 @@ import { reviewService } from '@/services/reviewService'
 import { Project } from '@/types/project'
 import { Review, ReviewCreate } from '@/types/review'
 import { toast } from 'react-hot-toast'
-import { ArrowLeft, Building2, Star, Briefcase, DollarSign, Link as LinkIcon } from 'lucide-react'
+import { ArrowLeft, Star, Briefcase, Link as LinkIcon } from 'lucide-react'
 import ReviewForm from '@/components/ReviewForm'
 import ReviewList from '@/components/ReviewList'
 

--- a/frontend/src/pages/CompanyDetailPage.tsx
+++ b/frontend/src/pages/CompanyDetailPage.tsx
@@ -1,0 +1,311 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
+import { clientService, ClientProfile } from '@/services/clientService'
+import { projectService } from '@/services/projectService'
+import { reviewService } from '@/services/reviewService'
+import { Project } from '@/types/project'
+import { Review, ReviewCreate } from '@/types/review'
+import { toast } from 'react-hot-toast'
+import { ArrowLeft, Building2, Star, Briefcase, DollarSign, Link as LinkIcon } from 'lucide-react'
+import ReviewForm from '@/components/ReviewForm'
+import ReviewList from '@/components/ReviewList'
+
+const CompanyDetailPage = () => {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { user } = useAuthStore()
+  const [company, setCompany] = useState<ClientProfile | null>(null)
+  const [projects, setProjects] = useState<Project[]>([])
+  const [reviews, setReviews] = useState<Review[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingProjects, setIsLoadingProjects] = useState(true)
+  const [isLoadingReviews, setIsLoadingReviews] = useState(true)
+  const [showReviewForm, setShowReviewForm] = useState(false)
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null)
+
+  useEffect(() => {
+    if (id) {
+      loadCompany()
+      loadProjects()
+      loadReviews()
+    }
+  }, [id])
+
+  const loadCompany = async () => {
+    try {
+      setIsLoading(true)
+      const data = await clientService.getById(id!)
+      setCompany(data)
+    } catch (error) {
+      console.error('Failed to load company:', error)
+      toast.error('Failed to load company profile')
+      navigate('/companies')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const loadProjects = async () => {
+    try {
+      setIsLoadingProjects(true)
+      const data = await projectService.getProjects({
+        client_id: id!,
+        limit: 100,
+      })
+      setProjects(data.items)
+    } catch (error) {
+      console.error('Failed to load projects:', error)
+    } finally {
+      setIsLoadingProjects(false)
+    }
+  }
+
+  const loadReviews = async () => {
+    try {
+      setIsLoadingReviews(true)
+      // Get reviews for company (where they were reviewed)
+      const data = await reviewService.getReviews({
+        reviewed_id: company?.user_id || id!,
+        limit: 100,
+      })
+      setReviews(data.items)
+    } catch (error) {
+      console.error('Failed to load reviews:', error)
+    } finally {
+      setIsLoadingReviews(false)
+    }
+  }
+
+  const handleSubmitReview = async (reviewData: ReviewCreate) => {
+    await reviewService.createReview(reviewData)
+    setShowReviewForm(false)
+    setSelectedProject(null)
+    loadReviews()
+    toast.success('Review submitted successfully!')
+  }
+
+  const canReviewCompany = (project: Project) => {
+    if (!user || !company) return false
+
+    // Must be completed
+    if (project.status !== 'COMPLETED') return false
+
+    // User must be the selected professional
+    if (project.selected_professional_id !== user.id) return false
+
+    // Check if already reviewed
+    const alreadyReviewed = reviews.some(r => r.project_id === project.id && r.reviewer_id === user.id)
+    return !alreadyReviewed
+  }
+
+  const handleReviewClick = (project: Project) => {
+    setSelectedProject(project)
+    setShowReviewForm(true)
+  }
+
+  const formatCurrency = (amount: number | null | undefined) => {
+    if (!amount) return 'Not specified'
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+    }).format(Number(amount))
+  }
+
+  const getStatusBadge = (status: string) => {
+    const badges: Record<string, string> = {
+      OPEN: 'bg-green-100 text-green-800',
+      IN_PROGRESS: 'bg-blue-100 text-blue-800',
+      COMPLETED: 'bg-gray-100 text-gray-800',
+      CANCELLED: 'bg-red-100 text-red-800',
+    }
+    return (
+      <span className={`px-3 py-1 text-sm font-medium rounded-full ${badges[status]}`}>
+        {status.replace('_', ' ')}
+      </span>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="card">
+          <div className="card-content">
+            <p className="text-gray-600">Loading company profile...</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!company) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="card">
+          <div className="card-content">
+            <p className="text-gray-600">Company not found.</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Back Button */}
+      <Link
+        to="/companies"
+        className="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-6"
+      >
+        <ArrowLeft className="w-5 h-5" />
+        Back to Companies
+      </Link>
+
+      {/* Company Header */}
+      <div className="card mb-6">
+        <div className="card-content">
+          <div className="flex items-start gap-4">
+            <div className="flex-shrink-0">
+              <div className="w-20 h-20 rounded-full bg-gradient-to-br from-green-500 to-blue-600 flex items-center justify-center text-white text-2xl font-bold">
+                {(company.company_name || 'C').charAt(0).toUpperCase()}
+              </div>
+            </div>
+            <div className="flex-1">
+              <h1 className="text-3xl font-bold text-gray-900 mb-2">
+                {company.company_name || 'Company'}
+              </h1>
+
+              {company.business_sector && (
+                <p className="text-gray-600 mb-2">
+                  <span className="font-medium">Sector:</span> {company.business_sector}
+                </p>
+              )}
+
+              {company.description && (
+                <p className="text-gray-700 mb-4">{company.description}</p>
+              )}
+
+              {company.bio && company.bio !== company.description && (
+                <p className="text-gray-700 mb-4">{company.bio}</p>
+              )}
+
+              <div className="flex flex-wrap gap-4 text-sm">
+                {company.average_rating && (
+                  <div className="flex items-center gap-1 text-gray-600">
+                    <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
+                    <span>{Number(company.average_rating).toFixed(1)} ({company.total_reviews} reviews)</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Links */}
+              {company.links && company.links.length > 0 && (
+                <div className="mt-4">
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">Links</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {company.links.map((link) => (
+                      <a
+                        key={link.id}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm"
+                      >
+                        <LinkIcon className="w-4 h-4" />
+                        {link.label || link.platform}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Projects Section */}
+      <div className="card mb-6">
+        <div className="card-header">
+          <h2 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+            <Briefcase className="w-5 h-5" />
+            Projects
+          </h2>
+        </div>
+        <div className="card-content">
+          {isLoadingProjects ? (
+            <p className="text-gray-600">Loading projects...</p>
+          ) : projects.length === 0 ? (
+            <p className="text-gray-600">No projects yet.</p>
+          ) : (
+            <div className="space-y-4">
+              {projects.map((project) => (
+                <div key={project.id} className="border border-gray-200 rounded-lg p-4">
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="flex-1">
+                      <Link
+                        to={`/projects/${project.id}`}
+                        className="text-lg font-semibold text-gray-900 hover:text-blue-600"
+                      >
+                        {project.title}
+                      </Link>
+                      <p className="text-sm text-gray-600 mt-1 line-clamp-2">{project.description}</p>
+                    </div>
+                    <div className="flex flex-col items-end gap-2">
+                      {getStatusBadge(project.status)}
+                      {canReviewCompany(project) && (
+                        <button
+                          onClick={() => handleReviewClick(project)}
+                          className="btn btn-primary btn-sm"
+                        >
+                          Leave Review
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  {project.budget && (
+                    <p className="text-sm text-gray-600">
+                      Budget: {formatCurrency(project.budget)}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Reviews Section */}
+      <div className="card">
+        <div className="card-header">
+          <h2 className="text-xl font-bold text-gray-900">Reviews</h2>
+        </div>
+        <div className="card-content">
+          {/* Review Form */}
+          {showReviewForm && selectedProject && company.user_id && (
+            <div className="mb-6 p-4 bg-gray-50 rounded-lg">
+              <h3 className="text-lg font-semibold mb-4">Review this Company</h3>
+              <p className="text-sm text-gray-600 mb-4">
+                Project: {selectedProject.title}
+              </p>
+              <ReviewForm
+                projectId={selectedProject.id}
+                reviewedUserId={company.user_id}
+                reviewType="professional_to_client"
+                onSubmit={handleSubmitReview}
+                onCancel={() => {
+                  setShowReviewForm(false)
+                  setSelectedProject(null)
+                }}
+              />
+            </div>
+          )}
+
+          {/* Review List */}
+          <ReviewList reviews={reviews} isLoading={isLoadingReviews} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default CompanyDetailPage

--- a/frontend/src/pages/ProfessionalDetailPage.tsx
+++ b/frontend/src/pages/ProfessionalDetailPage.tsx
@@ -7,7 +7,7 @@ import { reviewService } from '@/services/reviewService'
 import { Project } from '@/types/project'
 import { Review, ReviewCreate } from '@/types/review'
 import { toast } from 'react-hot-toast'
-import { ArrowLeft, User, Star, Briefcase, DollarSign, Mail, Link as LinkIcon } from 'lucide-react'
+import { ArrowLeft, Star, Briefcase, DollarSign, Link as LinkIcon } from 'lucide-react'
 import ReviewForm from '@/components/ReviewForm'
 import ReviewList from '@/components/ReviewList'
 

--- a/frontend/src/pages/ProfessionalDetailPage.tsx
+++ b/frontend/src/pages/ProfessionalDetailPage.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useState } from 'react'
+import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
+import { professionalService, ProfessionalProfile } from '@/services/professionalService'
+import { projectService } from '@/services/projectService'
+import { reviewService } from '@/services/reviewService'
+import { Project } from '@/types/project'
+import { Review, ReviewCreate } from '@/types/review'
+import { toast } from 'react-hot-toast'
+import { ArrowLeft, User, Star, Briefcase, DollarSign, Mail, Link as LinkIcon } from 'lucide-react'
+import ReviewForm from '@/components/ReviewForm'
+import ReviewList from '@/components/ReviewList'
+
+const ProfessionalDetailPage = () => {
+  const { id } = useParams()
+  const navigate = useNavigate()
+  const { user } = useAuthStore()
+  const [professional, setProfessional] = useState<ProfessionalProfile | null>(null)
+  const [projects, setProjects] = useState<Project[]>([])
+  const [reviews, setReviews] = useState<Review[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoadingProjects, setIsLoadingProjects] = useState(true)
+  const [isLoadingReviews, setIsLoadingReviews] = useState(true)
+  const [showReviewForm, setShowReviewForm] = useState(false)
+  const [selectedProject, setSelectedProject] = useState<Project | null>(null)
+
+  useEffect(() => {
+    if (id) {
+      loadProfessional()
+      loadProjects()
+      loadReviews()
+    }
+  }, [id])
+
+  const loadProfessional = async () => {
+    try {
+      setIsLoading(true)
+      const data = await professionalService.getById(id!)
+      setProfessional(data)
+    } catch (error) {
+      console.error('Failed to load professional:', error)
+      toast.error('Failed to load professional profile')
+      navigate('/professionals')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const loadProjects = async () => {
+    try {
+      setIsLoadingProjects(true)
+      const data = await projectService.getProjects({
+        professional_id: id!,
+        limit: 100,
+      })
+      setProjects(data.items)
+    } catch (error) {
+      console.error('Failed to load projects:', error)
+    } finally {
+      setIsLoadingProjects(false)
+    }
+  }
+
+  const loadReviews = async () => {
+    try {
+      setIsLoadingReviews(true)
+      // Get reviews for professional (where they were reviewed)
+      const data = await reviewService.getReviews({
+        reviewed_id: professional?.user_id || id!,
+        limit: 100,
+      })
+      setReviews(data.items)
+    } catch (error) {
+      console.error('Failed to load reviews:', error)
+    } finally {
+      setIsLoadingReviews(false)
+    }
+  }
+
+  const handleSubmitReview = async (reviewData: ReviewCreate) => {
+    await reviewService.createReview(reviewData)
+    setShowReviewForm(false)
+    setSelectedProject(null)
+    loadReviews()
+    toast.success('Review submitted successfully!')
+  }
+
+  const canReviewProfessional = (project: Project) => {
+    if (!user || !professional) return false
+
+    // Must be completed
+    if (project.status !== 'COMPLETED') return false
+
+    // User must be the client
+    if (project.client_id !== user.id) return false
+
+    // Check if already reviewed
+    const alreadyReviewed = reviews.some(r => r.project_id === project.id && r.reviewer_id === user.id)
+    return !alreadyReviewed
+  }
+
+  const handleReviewClick = (project: Project) => {
+    setSelectedProject(project)
+    setShowReviewForm(true)
+  }
+
+  const formatCurrency = (amount: number | null | undefined) => {
+    if (!amount) return 'Not specified'
+    return new Intl.NumberFormat('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+    }).format(Number(amount))
+  }
+
+  const getStatusBadge = (status: string) => {
+    const badges: Record<string, string> = {
+      OPEN: 'bg-green-100 text-green-800',
+      IN_PROGRESS: 'bg-blue-100 text-blue-800',
+      COMPLETED: 'bg-gray-100 text-gray-800',
+      CANCELLED: 'bg-red-100 text-red-800',
+    }
+    return (
+      <span className={`px-3 py-1 text-sm font-medium rounded-full ${badges[status]}`}>
+        {status.replace('_', ' ')}
+      </span>
+    )
+  }
+
+  if (isLoading) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="card">
+          <div className="card-content">
+            <p className="text-gray-600">Loading professional profile...</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!professional) {
+    return (
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="card">
+          <div className="card-content">
+            <p className="text-gray-600">Professional not found.</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      {/* Back Button */}
+      <Link
+        to="/professionals"
+        className="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-6"
+      >
+        <ArrowLeft className="w-5 h-5" />
+        Back to Professionals
+      </Link>
+
+      {/* Professional Header */}
+      <div className="card mb-6">
+        <div className="card-content">
+          <div className="flex items-start gap-4">
+            <div className="flex-shrink-0">
+              <div className="w-20 h-20 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white text-2xl font-bold">
+                {professional.title.charAt(0).toUpperCase()}
+              </div>
+            </div>
+            <div className="flex-1">
+              <h1 className="text-3xl font-bold text-gray-900 mb-2">{professional.title}</h1>
+              {professional.bio && (
+                <p className="text-gray-700 mb-4">{professional.bio}</p>
+              )}
+
+              <div className="flex flex-wrap gap-4 text-sm">
+                {professional.hourly_rate && (
+                  <div className="flex items-center gap-1 text-gray-600">
+                    <DollarSign className="w-4 h-4" />
+                    <span>{formatCurrency(professional.hourly_rate)}/hour</span>
+                  </div>
+                )}
+
+                {professional.average_rating && (
+                  <div className="flex items-center gap-1 text-gray-600">
+                    <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
+                    <span>{Number(professional.average_rating).toFixed(1)} ({professional.total_reviews} reviews)</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Skills */}
+              {professional.skills && professional.skills.length > 0 && (
+                <div className="mt-4">
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">Skills</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {professional.skills.map((skill, index) => (
+                      <span
+                        key={index}
+                        className="px-3 py-1 bg-blue-100 text-blue-800 text-sm rounded-full"
+                      >
+                        {skill.skill?.name || 'Skill'}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Links */}
+              {professional.links && professional.links.length > 0 && (
+                <div className="mt-4">
+                  <h3 className="text-sm font-medium text-gray-700 mb-2">Links</h3>
+                  <div className="flex flex-wrap gap-2">
+                    {professional.links.map((link) => (
+                      <a
+                        key={link.id}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm"
+                      >
+                        <LinkIcon className="w-4 h-4" />
+                        {link.label || link.platform}
+                      </a>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Projects Section */}
+      <div className="card mb-6">
+        <div className="card-header">
+          <h2 className="text-xl font-bold text-gray-900 flex items-center gap-2">
+            <Briefcase className="w-5 h-5" />
+            Projects
+          </h2>
+        </div>
+        <div className="card-content">
+          {isLoadingProjects ? (
+            <p className="text-gray-600">Loading projects...</p>
+          ) : projects.length === 0 ? (
+            <p className="text-gray-600">No projects yet.</p>
+          ) : (
+            <div className="space-y-4">
+              {projects.map((project) => (
+                <div key={project.id} className="border border-gray-200 rounded-lg p-4">
+                  <div className="flex justify-between items-start mb-3">
+                    <div className="flex-1">
+                      <Link
+                        to={`/projects/${project.id}`}
+                        className="text-lg font-semibold text-gray-900 hover:text-blue-600"
+                      >
+                        {project.title}
+                      </Link>
+                      <p className="text-sm text-gray-600 mt-1 line-clamp-2">{project.description}</p>
+                    </div>
+                    <div className="flex flex-col items-end gap-2">
+                      {getStatusBadge(project.status)}
+                      {canReviewProfessional(project) && (
+                        <button
+                          onClick={() => handleReviewClick(project)}
+                          className="btn btn-primary btn-sm"
+                        >
+                          Leave Review
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  {project.budget && (
+                    <p className="text-sm text-gray-600">
+                      Budget: {formatCurrency(project.budget)}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Reviews Section */}
+      <div className="card">
+        <div className="card-header">
+          <h2 className="text-xl font-bold text-gray-900">Reviews</h2>
+        </div>
+        <div className="card-content">
+          {/* Review Form */}
+          {showReviewForm && selectedProject && professional.user_id && (
+            <div className="mb-6 p-4 bg-gray-50 rounded-lg">
+              <h3 className="text-lg font-semibold mb-4">Review this Professional</h3>
+              <p className="text-sm text-gray-600 mb-4">
+                Project: {selectedProject.title}
+              </p>
+              <ReviewForm
+                projectId={selectedProject.id}
+                reviewedUserId={professional.user_id}
+                reviewType="client_to_professional"
+                onSubmit={handleSubmitReview}
+                onCancel={() => {
+                  setShowReviewForm(false)
+                  setSelectedProject(null)
+                }}
+              />
+            </div>
+          )}
+
+          {/* Review List */}
+          <ReviewList reviews={reviews} isLoading={isLoadingReviews} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProfessionalDetailPage

--- a/frontend/src/pages/ProfessionalsPage.tsx
+++ b/frontend/src/pages/ProfessionalsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { professionalService, ProfessionalProfile } from '@/services/professionalService'
 
 const ProfessionalsPage = () => {
@@ -39,15 +40,22 @@ const ProfessionalsPage = () => {
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {items.map((p) => (
-            <div key={p.id} className="card">
+            <Link key={p.id} to={`/professionals/${p.id}`} className="card hover:shadow-lg transition-shadow">
               <div className="card-content">
-                <h3 className="text-lg font-semibold text-gray-900">{p.title}</h3>
+                <h3 className="text-lg font-semibold text-gray-900 hover:text-blue-600 transition-colors">{p.title}</h3>
                 {p.bio && <p className="mt-2 text-gray-700 line-clamp-3">{p.bio}</p>}
-                {p.hourly_rate != null && (
-                  <p className="mt-2 text-gray-600 text-sm">Hourly: R$ {Number(p.hourly_rate).toFixed(2)}</p>
-                )}
+                <div className="mt-3 flex items-center justify-between text-sm">
+                  {p.hourly_rate != null && (
+                    <p className="text-gray-600">R$ {Number(p.hourly_rate).toFixed(2)}/hour</p>
+                  )}
+                  {p.average_rating != null && (
+                    <p className="text-yellow-600 font-medium">
+                      ⭐ {Number(p.average_rating).toFixed(1)}
+                    </p>
+                  )}
+                </div>
               </div>
-            </div>
+            </Link>
           ))}
         </div>
       )}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -3,10 +3,12 @@ import { useParams, useNavigate, Link } from 'react-router-dom'
 import { useAuthStore } from '@/stores/authStore'
 import { projectService } from '@/services/projectService'
 import { reviewService } from '@/services/reviewService'
+import { proposalService } from '@/services/proposalService'
+import { professionalService } from '@/services/professionalService'
 import { Project } from '@/types/project'
 import { Review, ReviewCreate } from '@/types/review'
 import { toast } from 'react-hot-toast'
-import { ArrowLeft, Briefcase, Calendar, DollarSign, User } from 'lucide-react'
+import { ArrowLeft, Briefcase, Calendar, DollarSign, User, Send } from 'lucide-react'
 import ReviewForm from '@/components/ReviewForm'
 import ReviewList from '@/components/ReviewList'
 
@@ -19,13 +21,39 @@ const ProjectDetailPage = () => {
   const [isLoading, setIsLoading] = useState(true)
   const [isLoadingReviews, setIsLoadingReviews] = useState(true)
   const [showReviewForm, setShowReviewForm] = useState(false)
+  const [showProposalForm, setShowProposalForm] = useState(false)
+  const [proposalDescription, setProposalDescription] = useState('')
+  const [proposalAmount, setProposalAmount] = useState('')
+  const [proposalDays, setProposalDays] = useState('')
+  const [isSubmittingProposal, setIsSubmittingProposal] = useState(false)
+  const [hasApplied, setHasApplied] = useState(false)
 
   useEffect(() => {
     if (id) {
       loadProject()
       loadReviews()
+      checkIfApplied()
     }
   }, [id])
+
+  const checkIfApplied = async () => {
+    if (!user || !id) return
+
+    try {
+      const professionalProfile = await professionalService.getMyProfile()
+      if (professionalProfile) {
+        const proposals = await proposalService.getProposals({
+          project_id: id,
+          professional_id: professionalProfile.id,
+          limit: 1,
+        })
+        setHasApplied(proposals.items.length > 0)
+      }
+    } catch (error) {
+      // User might not have a professional profile
+      console.log('Could not check proposal status:', error)
+    }
+  }
 
   const loadProject = async () => {
     try {
@@ -59,6 +87,37 @@ const ProjectDetailPage = () => {
     loadReviews()
   }
 
+  const handleSubmitProposal = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!proposalAmount || !proposalDescription) {
+      toast.error('Please fill in all required fields')
+      return
+    }
+
+    try {
+      setIsSubmittingProposal(true)
+      await proposalService.createProposal({
+        project_id: id!,
+        proposed_amount: Number(proposalAmount),
+        estimated_days: proposalDays ? Number(proposalDays) : undefined,
+        description: proposalDescription,
+      })
+
+      toast.success('Proposal submitted successfully!')
+      setShowProposalForm(false)
+      setProposalDescription('')
+      setProposalAmount('')
+      setProposalDays('')
+      setHasApplied(true)
+    } catch (error: any) {
+      console.error('Failed to submit proposal:', error)
+      toast.error(error.response?.data?.detail || 'Failed to submit proposal')
+    } finally {
+      setIsSubmittingProposal(false)
+    }
+  }
+
   const formatCurrency = (amount: number | null) => {
     if (!amount) return 'Not specified'
     return new Intl.NumberFormat('pt-BR', {
@@ -84,6 +143,22 @@ const ProjectDetailPage = () => {
         {status.replace('_', ' ')}
       </span>
     )
+  }
+
+  // Check if professional can apply to project
+  const canApplyToProject = () => {
+    if (!project || !user) return false
+
+    // Project must be OPEN
+    if (project.status !== 'OPEN') return false
+
+    // User must not be the project owner
+    if (project.client_id === user.id) return false
+
+    // User must not have already applied
+    if (hasApplied) return false
+
+    return true
   }
 
   // Check if user can leave a review
@@ -238,6 +313,122 @@ const ProjectDetailPage = () => {
           </div>
         </div>
       </div>
+
+      {/* Apply to Project Section */}
+      {canApplyToProject() && (
+        <div className="card mb-6">
+          <div className="card-header">
+            <h2 className="text-xl font-bold text-gray-900">Apply to this Project</h2>
+          </div>
+          <div className="card-content">
+            {!showProposalForm ? (
+              <div className="text-center py-4">
+                <p className="text-gray-600 mb-4">
+                  Interested in this project? Submit a proposal to get started!
+                </p>
+                <button
+                  onClick={() => setShowProposalForm(true)}
+                  className="btn btn-primary inline-flex items-center gap-2"
+                >
+                  <Send className="w-4 h-4" />
+                  Submit Proposal
+                </button>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmitProposal} className="space-y-4">
+                <div>
+                  <label htmlFor="proposalAmount" className="block text-sm font-medium text-gray-700 mb-1">
+                    Proposed Amount (BRL) <span className="text-red-500">*</span>
+                  </label>
+                  <input
+                    id="proposalAmount"
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    value={proposalAmount}
+                    onChange={(e) => setProposalAmount(e.target.value)}
+                    className="input"
+                    placeholder="10000.00"
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="proposalDays" className="block text-sm font-medium text-gray-700 mb-1">
+                    Estimated Days
+                  </label>
+                  <input
+                    id="proposalDays"
+                    type="number"
+                    min="1"
+                    value={proposalDays}
+                    onChange={(e) => setProposalDays(e.target.value)}
+                    className="input"
+                    placeholder="30"
+                  />
+                </div>
+
+                <div>
+                  <label htmlFor="proposalDescription" className="block text-sm font-medium text-gray-700 mb-1">
+                    Proposal Description <span className="text-red-500">*</span>
+                  </label>
+                  <textarea
+                    id="proposalDescription"
+                    value={proposalDescription}
+                    onChange={(e) => setProposalDescription(e.target.value)}
+                    rows={6}
+                    className="input"
+                    placeholder="Explain your approach to this project, relevant experience, and why you're the best fit..."
+                    required
+                    maxLength={2000}
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    {proposalDescription.length}/2000 characters
+                  </p>
+                </div>
+
+                <div className="flex gap-3">
+                  <button
+                    type="submit"
+                    disabled={isSubmittingProposal}
+                    className="btn btn-primary flex-1"
+                  >
+                    {isSubmittingProposal ? 'Submitting...' : 'Submit Proposal'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setShowProposalForm(false)
+                      setProposalDescription('')
+                      setProposalAmount('')
+                      setProposalDays('')
+                    }}
+                    disabled={isSubmittingProposal}
+                    className="btn btn-secondary"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            )}
+          </div>
+        </div>
+      )}
+
+      {hasApplied && !canApplyToProject() && project.status === 'OPEN' && (
+        <div className="card mb-6">
+          <div className="card-content">
+            <div className="text-center py-4">
+              <p className="text-green-600 font-medium">
+                You have already submitted a proposal for this project
+              </p>
+              <p className="text-sm text-gray-600 mt-1">
+                The client will review your proposal and get back to you.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Reviews Section */}
       <div className="card">

--- a/frontend/src/services/clientService.ts
+++ b/frontend/src/services/clientService.ts
@@ -1,12 +1,25 @@
 import { apiClient } from './api'
 
+export interface ClientLink {
+  id: string
+  client_id: string
+  platform: string
+  url: string
+  label: string | null
+  created_at: string
+  updated_at: string
+}
+
 export interface ClientProfile {
   id: string
   user_id: string
   company_name?: string | null
   business_sector?: string | null
+  description?: string | null
+  bio?: string | null
   average_rating?: number | null
   total_reviews: number
+  links?: ClientLink[]
   created_at: string
   updated_at: string
 }
@@ -22,6 +35,11 @@ export const clientService = {
   async list(params?: { skip?: number; limit?: number; business_sector?: string }) {
     const response = await apiClient.get('/clients', { params })
     return response.data as { items: ClientProfile[]; total: number; page: number; size: number; pages: number }
+  },
+
+  async getById(id: string): Promise<ClientProfile> {
+    const response = await apiClient.get<ClientProfile>(`/clients/${id}`)
+    return response.data
   },
 
   async createProfile(data: ClientProfileCreate): Promise<ClientProfile> {

--- a/frontend/src/services/professionalService.ts
+++ b/frontend/src/services/professionalService.ts
@@ -22,6 +22,20 @@ export interface ProfessionalLinkUpdate {
   label?: string | null;
 }
 
+export interface ProfessionalSkill {
+  id: string;
+  professional_id: string;
+  skill_id: string;
+  proficiency_level: number;
+  years_experience: number | null;
+  certified: number;
+  skill?: {
+    id: string;
+    name: string;
+    category: string;
+  };
+}
+
 export interface ProfessionalProfile {
   id: string;
   user_id: string;
@@ -31,7 +45,8 @@ export interface ProfessionalProfile {
   hourly_rate: number | null;
   average_rating: number | null;
   total_reviews: number;
-  links: ProfessionalLink[];
+  links?: ProfessionalLink[];
+  skills?: ProfessionalSkill[];
   created_at: string;
   updated_at: string;
 }
@@ -68,6 +83,11 @@ export const professionalService = {
 
   async updateMyProfile(data: ProfessionalProfileUpdate): Promise<ProfessionalProfile> {
     const response = await apiClient.put<ProfessionalProfile>('/professionals/me', data);
+    return response.data;
+  },
+
+  async getById(id: string): Promise<ProfessionalProfile> {
+    const response = await apiClient.get<ProfessionalProfile>(`/professionals/${id}`);
     return response.data;
   },
 


### PR DESCRIPTION
Add comprehensive improvements to the platform before AI implementation:

Rebrand:
- Rename from SaasPlatform to MindHire
- Add slogan: Conectando talentos com inteligência
- Update copyright year to 2025

Features for Companies:
- Add professionals listing page with clickable cards
- Create professional detail page showing all projects and ratings
- Enable feedback system (1-5 stars + optional comment)

Features for Professionals:
- Add companies listing page with clickable cards
- Create company detail page showing all projects and ratings
- Enable feedback system for companies

Project Application System:
- Add proposal/application form in project details
- Professionals can apply to OPEN projects
- Display application status to users
- Companies can accept/reject proposals

Testing:
- Add factories using factory_boy and faker
- Create comprehensive unit tests for proposals
- Create comprehensive unit tests for reviews