### PR TITLE
fix: disable pool_pre_ping to resolve psycopg2 compatibility issue

### DIFF
--- a/backend/app/database/session.py
+++ b/backend/app/database/session.py
@@ -14,7 +14,7 @@ engine = create_engine(
     settings.database_url,
     poolclass=StaticPool,
     echo=settings.debug,
-    pool_pre_ping=True,
+    pool_pre_ping=False,  # Disabled due to psycopg2 + Python 3.13 compatibility issue
 )
 
 # Create session factory


### PR DESCRIPTION
Disabled pool_pre_ping in SQLAlchemy engine configuration to fix 'set_session cannot be used inside a transaction' error occurring with psycopg2 + Python 3.13 combination.

This resolves 500 errors on production endpoints including:
- /api/v1/professionals/{id}
- /api/v1/clients/{id}
- /api/v1/reviews/
- And various other endpoints

The pool_pre_ping feature attempts to verify connections before use, but psycopg2 cannot handle the autocommit setting change when already inside a transaction, causing the application to crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)