### PR TITLE
fix: standardize project status values to UPPERCASE

### DIFF
--- a/backend/alembic/versions/9afa730d5a92_update_project_status_to_uppercase.py
+++ b/backend/alembic/versions/9afa730d5a92_update_project_status_to_uppercase.py
@@ -1,0 +1,40 @@
+"""update_project_status_to_uppercase
+
+Revision ID: 9afa730d5a92
+Revises: 57fb0d64d5d
+Create Date: 2025-11-03 15:17:09.923498
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9afa730d5a92"
+down_revision = "57fb0d64d5d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Update existing project status values from lowercase to UPPERCASE."""
+    # Update all existing projects to use UPPERCASE status values
+    op.execute(
+        """
+        UPDATE projects
+        SET status = UPPER(status)
+        WHERE status IN ('open', 'in_progress', 'completed', 'cancelled')
+    """
+    )
+
+
+def downgrade() -> None:
+    """Revert project status values back to lowercase."""
+    # Revert all projects back to lowercase status values
+    op.execute(
+        """
+        UPDATE projects
+        SET status = LOWER(status)
+        WHERE status IN ('OPEN', 'IN_PROGRESS', 'COMPLETED', 'CANCELLED')
+    """
+    )

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -12,10 +12,10 @@ from app.models.base import BaseModel
 class ProjectStatus(str, Enum):
     """Project status enumeration."""
 
-    OPEN = "open"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-    CANCELLED = "cancelled"
+    OPEN = "OPEN"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
 
 
 class Project(BaseModel):

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -12,10 +12,10 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 class ProjectStatus(str, Enum):
     """Project status enumeration."""
 
-    OPEN = "open"
-    IN_PROGRESS = "in_progress"
-    COMPLETED = "completed"
-    CANCELLED = "cancelled"
+    OPEN = "OPEN"
+    IN_PROGRESS = "IN_PROGRESS"
+    COMPLETED = "COMPLETED"
+    CANCELLED = "CANCELLED"
 
 
 class ProjectBase(BaseModel):

--- a/frontend/src/services/projectService.ts
+++ b/frontend/src/services/projectService.ts
@@ -13,7 +13,8 @@ export const projectService = {
   async getProjects(filters?: ProjectFilters): Promise<PaginatedProjects> {
     const params = new URLSearchParams()
 
-    if (filters?.status) params.append('status', filters.status)
+    // Backend expects 'status_filter' not 'status'
+    if (filters?.status) params.append('status_filter', filters.status)
     if (filters?.client_id) params.append('client_id', filters.client_id)
     if (filters?.professional_id) params.append('professional_id', filters.professional_id)
     if (filters?.only_open !== undefined) params.append('only_open', String(filters.only_open))


### PR DESCRIPTION
This commit fixes multiple issues with project status handling and filtering:

## Backend Changes
1. **Status Values**: Changed ProjectStatus enum values from lowercase to UPPERCASE
   - `backend/app/schemas/project.py`: Updated schema enum
   - `backend/app/models/project.py`: Updated model enum
   - Ensures consistency between frontend and backend

2. **Database Migration**: Added migration to update existing data
   - `backend/alembic/versions/9afa730d5a92_update_project_status_to_uppercase.py`
   - Converts all existing project status values to UPPERCASE
   - Includes downgrade function for rollback

## Frontend Changes
1. **API Query Parameter**: Fixed project filtering
   - `frontend/src/services/projectService.ts`
   - Changed `status` to `status_filter` to match backend API
   - Fixes issue where status filters weren't working

## Issues Fixed
- ✅ Status filter not working (all projects shown regardless of filter)
- ✅ Review buttons not appearing (status comparison failing due to case mismatch)
- ✅ Project completion detection failing

## Root Cause
Backend was returning lowercase status values ("completed") but frontend was comparing with UPPERCASE ("COMPLETED"), causing all status-based conditions to fail.

## Testing
- ✅ Backend linter passed (ruff check & format)
- ✅ Frontend type-check passed
- ✅ Frontend build successful
