### PR TITLE
fix: resolve project status management and proposal issues

### DIFF
--- a/backend/alembic/versions/0001_initial_migration.py
+++ b/backend/alembic/versions/0001_initial_migration.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2025-10-23 22:30:00
 
 """
+
 from collections.abc import Sequence
 from typing import Union
 

--- a/backend/alembic/versions/0e442c50bf8_add_client_profile_fields_and_client_links.py
+++ b/backend/alembic/versions/0e442c50bf8_add_client_profile_fields_and_client_links.py
@@ -5,6 +5,7 @@ Revises: 855af8631231
 Create Date: 2025-10-29 22:30:00.000000
 
 """
+
 import sqlalchemy as sa
 
 from alembic import op

--- a/backend/alembic/versions/3b12615ab738_add_bio_field_to_professional_profiles.py
+++ b/backend/alembic/versions/3b12615ab738_add_bio_field_to_professional_profiles.py
@@ -5,6 +5,7 @@ Revises: 31eeee5d1792
 Create Date: 2025-10-28 11:12:15.469435
 
 """
+
 import sqlalchemy as sa
 
 from alembic import op

--- a/backend/alembic/versions/55b914fd2168_add_admin_role_to_account_type.py
+++ b/backend/alembic/versions/55b914fd2168_add_admin_role_to_account_type.py
@@ -6,7 +6,6 @@ Create Date: 2025-10-28 14:22:06.409281
 
 """
 
-
 # revision identifiers, used by Alembic.
 revision = "55b914fd2168"
 down_revision = "855af8631231"

--- a/backend/alembic/versions/57fb0d64d5d_merge_heads.py
+++ b/backend/alembic/versions/57fb0d64d5d_merge_heads.py
@@ -6,7 +6,6 @@ Create Date: 2025-10-29 22:45:00.000000
 
 """
 
-
 # revision identifiers, used by Alembic.
 revision = "57fb0d64d5d"
 down_revision = ("0e442c50bf8", "dfc933efdaae")

--- a/backend/alembic/versions/855af8631231_create_professional_links_table.py
+++ b/backend/alembic/versions/855af8631231_create_professional_links_table.py
@@ -5,6 +5,7 @@ Revises: 3b12615ab738
 Create Date: 2025-10-28 11:20:56.614533
 
 """
+
 import sqlalchemy as sa
 
 from alembic import op

--- a/backend/alembic/versions/dfc933efdaae_add_requirements_field_to_projects.py
+++ b/backend/alembic/versions/dfc933efdaae_add_requirements_field_to_projects.py
@@ -5,6 +5,7 @@ Revises: 55b914fd2168
 Create Date: 2025-10-28 16:52:54.831769
 
 """
+
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 

--- a/backend/app/api/v1/endpoints/clients.py
+++ b/backend/app/api/v1/endpoints/clients.py
@@ -1,6 +1,5 @@
 """Client endpoints."""
 
-from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -49,7 +48,7 @@ async def create_client_profile(
 async def list_clients(
     skip: int = 0,
     limit: int = 20,
-    business_sector: Optional[str] = None,
+    business_sector: str | None = None,
     client_service: ClientService = Depends(get_client_service),
 ) -> PaginatedResponse[ClientProfileResponse]:
     """List clients with pagination (public endpoint)."""

--- a/backend/app/api/v1/endpoints/projects.py
+++ b/backend/app/api/v1/endpoints/projects.py
@@ -1,6 +1,5 @@
 """Project endpoints."""
 
-from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -19,6 +18,7 @@ from app.schemas.project import (
     ProjectUpdate,
 )
 from app.services.client_service import ClientService
+from app.services.professional_service import ProfessionalService
 from app.services.project_service import ProjectService
 
 router = APIRouter()
@@ -38,6 +38,17 @@ def get_client_service(db: Session = Depends(get_db)) -> ClientService:
     """Get client service dependency."""
     client_repository = ClientRepository(db)
     return ClientService(client_repository)
+
+
+def get_professional_service(db: Session = Depends(get_db)) -> ProfessionalService:
+    """Get professional service dependency."""
+    from app.repositories.skill_repository import SkillRepository
+
+    professional_repository = ProfessionalRepository(db)
+    skill_repository = SkillRepository(db)
+    from app.services.professional_service import ProfessionalService
+
+    return ProfessionalService(professional_repository, skill_repository)
 
 
 @router.post("/", response_model=ProjectResponse, status_code=status.HTTP_201_CREATED)
@@ -68,9 +79,9 @@ async def create_project(
 async def list_projects(
     skip: int = 0,
     limit: int = 20,
-    status_filter: Optional[ProjectStatus] = None,
-    client_id: Optional[str] = None,
-    professional_id: Optional[str] = None,
+    status_filter: ProjectStatus | None = None,
+    client_id: str | None = None,
+    professional_id: str | None = None,
     only_open: bool = False,
     project_service: ProjectService = Depends(get_project_service),
 ) -> PaginatedResponse[ProjectResponse]:
@@ -291,5 +302,77 @@ async def cancel_project(
             )
 
         return await project_service.cancel_project(project_uuid)
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.patch("/{project_id}/start", response_model=ProjectResponse)
+async def start_project(
+    project_id: str,
+    current_user_id: str = Depends(get_current_user_id),
+    project_service: ProjectService = Depends(get_project_service),
+    professional_service: ProfessionalService = Depends(get_professional_service),
+) -> ProjectResponse:
+    """Start project (only assigned professional can start - OPEN to IN_PROGRESS)."""
+    try:
+        project_uuid = UUID(project_id)
+        user_uuid = UUID(current_user_id)
+
+        # Verify project exists
+        project = await project_service.get_project_by_id(project_uuid)
+        if not project:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
+            )
+
+        # Verify user is a professional
+        professional_profile = await professional_service.get_profile_by_user_id(
+            user_uuid
+        )
+        if not professional_profile:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only professionals can start projects",
+            )
+
+        return await project_service.start_project(
+            project_uuid, professional_profile.id
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.patch("/{project_id}/complete-by-professional", response_model=ProjectResponse)
+async def complete_project_by_professional(
+    project_id: str,
+    current_user_id: str = Depends(get_current_user_id),
+    project_service: ProjectService = Depends(get_project_service),
+    professional_service: ProfessionalService = Depends(get_professional_service),
+) -> ProjectResponse:
+    """Complete project (only assigned professional can complete - IN_PROGRESS to COMPLETED)."""
+    try:
+        project_uuid = UUID(project_id)
+        user_uuid = UUID(current_user_id)
+
+        # Verify project exists
+        project = await project_service.get_project_by_id(project_uuid)
+        if not project:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
+            )
+
+        # Verify user is a professional
+        professional_profile = await professional_service.get_profile_by_user_id(
+            user_uuid
+        )
+        if not professional_profile:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only professionals can complete projects",
+            )
+
+        return await project_service.complete_project_by_professional(
+            project_uuid, professional_profile.id
+        )
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/backend/app/api/v1/endpoints/proposals.py
+++ b/backend/app/api/v1/endpoints/proposals.py
@@ -1,6 +1,5 @@
 """Proposal endpoints."""
 
-from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -82,9 +81,9 @@ async def create_proposal(
 async def list_proposals(
     skip: int = 0,
     limit: int = 20,
-    project_id: Optional[str] = None,
-    professional_id: Optional[str] = None,
-    status_filter: Optional[ProposalStatus] = None,
+    project_id: str | None = None,
+    professional_id: str | None = None,
+    status_filter: ProposalStatus | None = None,
     current_user_id: str = Depends(get_current_user_id),
     proposal_service: ProposalService = Depends(get_proposal_service),
 ) -> PaginatedResponse[ProposalResponse]:

--- a/backend/app/api/v1/endpoints/reviews.py
+++ b/backend/app/api/v1/endpoints/reviews.py
@@ -1,6 +1,5 @@
 """Review endpoints."""
 
-from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -54,10 +53,10 @@ async def create_review(
 async def list_reviews(
     skip: int = 0,
     limit: int = 20,
-    project_id: Optional[str] = None,
-    reviewer_id: Optional[str] = None,
-    reviewed_id: Optional[str] = None,
-    review_type: Optional[ReviewType] = None,
+    project_id: str | None = None,
+    reviewer_id: str | None = None,
+    reviewed_id: str | None = None,
+    review_type: ReviewType | None = None,
     review_service: ReviewService = Depends(get_review_service),
 ) -> PaginatedResponse[ReviewResponse]:
     """List reviews with pagination and filters (public endpoint)."""

--- a/backend/app/api/v1/endpoints/skills.py
+++ b/backend/app/api/v1/endpoints/skills.py
@@ -1,6 +1,5 @@
 """Skill endpoints."""
 
-from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -39,8 +38,8 @@ async def create_skill(
 async def list_skills(
     skip: int = 0,
     limit: int = 20,
-    category: Optional[str] = None,
-    search: Optional[str] = None,
+    category: str | None = None,
+    search: str | None = None,
     only_active: bool = True,
     skill_service: SkillService = Depends(get_skill_service),
 ) -> PaginatedResponse[SkillResponse]:

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,7 +1,6 @@
 """Application configuration settings."""
 
 import json
-from typing import Optional
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
@@ -71,13 +70,11 @@ class Settings(BaseSettings):
         default=[".jpg", ".jpeg", ".png", ".pdf", ".doc", ".docx"]
     )
 
-    aws_access_key_id: Optional[str] = Field(default=None, env="AWS_ACCESS_KEY_ID")
-    aws_secret_access_key: Optional[str] = Field(
-        default=None, env="AWS_SECRET_ACCESS_KEY"
-    )
+    aws_access_key_id: str | None = Field(default=None, env="AWS_ACCESS_KEY_ID")
+    aws_secret_access_key: str | None = Field(default=None, env="AWS_SECRET_ACCESS_KEY")
     aws_region: str = Field(default="sa-east-1", env="AWS_REGION")
-    aws_s3_bucket: Optional[str] = Field(default=None, env="AWS_S3_BUCKET")
-    s3_endpoint_url: Optional[str] = Field(default=None, env="S3_ENDPOINT_URL")
+    aws_s3_bucket: str | None = Field(default=None, env="AWS_S3_BUCKET")
+    s3_endpoint_url: str | None = Field(default=None, env="S3_ENDPOINT_URL")
 
     @field_validator("allowed_file_types", mode="before")
     @classmethod
@@ -99,18 +96,18 @@ class Settings(BaseSettings):
     ai_max_tokens: int = Field(default=1024, env="AI_MAX_TOKENS")
     ai_temperature: float = Field(default=0.7, env="AI_TEMPERATURE")
 
-    huggingface_api_key: Optional[str] = Field(default=None, env="HUGGINGFACE_API_KEY")
-    together_api_key: Optional[str] = Field(default=None, env="TOGETHER_API_KEY")
-    openrouter_api_key: Optional[str] = Field(default=None, env="OPENROUTER_API_KEY")
+    huggingface_api_key: str | None = Field(default=None, env="HUGGINGFACE_API_KEY")
+    together_api_key: str | None = Field(default=None, env="TOGETHER_API_KEY")
+    openrouter_api_key: str | None = Field(default=None, env="OPENROUTER_API_KEY")
 
     # Email Service - Resend
-    resend_api_key: Optional[str] = Field(default=None, env="RESEND_API_KEY")
+    resend_api_key: str | None = Field(default=None, env="RESEND_API_KEY")
     from_email: str = Field(default="noreply@saas-platform.com", env="FROM_EMAIL")
     from_name: str = Field(default="SaaS Platform", env="FROM_NAME")
 
     # Monitoring - Sentry
-    sentry_dsn_backend: Optional[str] = Field(default=None, env="SENTRY_DSN_BACKEND")
-    sentry_dsn_frontend: Optional[str] = Field(default=None, env="SENTRY_DSN_FRONTEND")
+    sentry_dsn_backend: str | None = Field(default=None, env="SENTRY_DSN_BACKEND")
+    sentry_dsn_frontend: str | None = Field(default=None, env="SENTRY_DSN_FRONTEND")
     sentry_environment: str = Field(default="production", env="SENTRY_ENVIRONMENT")
     sentry_traces_sample_rate: float = Field(
         default=0.1, env="SENTRY_TRACES_SAMPLE_RATE"

--- a/backend/app/core/exceptions.py
+++ b/backend/app/core/exceptions.py
@@ -1,6 +1,6 @@
 """Custom exceptions for the application."""
 
-from typing import Any, Optional
+from typing import Any
 
 
 class SaaSPlatformException(Exception):
@@ -9,8 +9,8 @@ class SaaSPlatformException(Exception):
     def __init__(
         self,
         message: str,
-        error_code: Optional[str] = None,
-        details: Optional[dict[str, Any]] = None,
+        error_code: str | None = None,
+        details: dict[str, Any] | None = None,
     ) -> None:
         """Initialize exception."""
         super().__init__(message)
@@ -22,7 +22,7 @@ class SaaSPlatformException(Exception):
 class ValidationError(SaaSPlatformException):
     """Validation error exception."""
 
-    def __init__(self, message: str, field: Optional[str] = None) -> None:
+    def __init__(self, message: str, field: str | None = None) -> None:
         """Initialize validation error."""
         super().__init__(message, "VALIDATION_ERROR", {"field": field})
 
@@ -46,7 +46,7 @@ class AuthorizationError(SaaSPlatformException):
 class NotFoundError(SaaSPlatformException):
     """Resource not found exception."""
 
-    def __init__(self, resource: str, resource_id: Optional[str] = None) -> None:
+    def __init__(self, resource: str, resource_id: str | None = None) -> None:
         """Initialize not found error."""
         message = f"{resource} not found"
         if resource_id:
@@ -61,7 +61,7 @@ class NotFoundError(SaaSPlatformException):
 class ConflictError(SaaSPlatformException):
     """Resource conflict exception."""
 
-    def __init__(self, message: str, resource: Optional[str] = None) -> None:
+    def __init__(self, message: str, resource: str | None = None) -> None:
         """Initialize conflict error."""
         super().__init__(message, "CONFLICT_ERROR", {"resource": resource})
 
@@ -69,7 +69,7 @@ class ConflictError(SaaSPlatformException):
 class DatabaseError(SaaSPlatformException):
     """Database error exception."""
 
-    def __init__(self, message: str, operation: Optional[str] = None) -> None:
+    def __init__(self, message: str, operation: str | None = None) -> None:
         """Initialize database error."""
         super().__init__(message, "DATABASE_ERROR", {"operation": operation})
 
@@ -77,7 +77,7 @@ class DatabaseError(SaaSPlatformException):
 class ExternalServiceError(SaaSPlatformException):
     """External service error exception."""
 
-    def __init__(self, message: str, service: Optional[str] = None) -> None:
+    def __init__(self, message: str, service: str | None = None) -> None:
         """Initialize external service error."""
         super().__init__(message, "EXTERNAL_SERVICE_ERROR", {"service": service})
 
@@ -93,7 +93,7 @@ class RateLimitError(SaaSPlatformException):
 class BusinessLogicError(SaaSPlatformException):
     """Business logic error exception."""
 
-    def __init__(self, message: str, business_rule: Optional[str] = None) -> None:
+    def __init__(self, message: str, business_rule: str | None = None) -> None:
         """Initialize business logic error."""
         super().__init__(
             message, "BUSINESS_LOGIC_ERROR", {"business_rule": business_rule}

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,7 +1,6 @@
 """Security utilities for authentication and authorization."""
 
 from datetime import datetime, timedelta
-from typing import Optional
 
 from fastapi import Depends
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -29,7 +28,7 @@ def get_password_hash(password: str) -> str:
 
 def create_access_token(
     data: dict,
-    expires_delta: Optional[timedelta] = None,
+    expires_delta: timedelta | None = None,
 ) -> str:
     """Create JWT access token."""
     to_encode = data.copy()
@@ -49,7 +48,7 @@ def create_access_token(
 
 def create_refresh_token(
     data: dict,
-    expires_delta: Optional[timedelta] = None,
+    expires_delta: timedelta | None = None,
 ) -> str:
     """Create JWT refresh token."""
     to_encode = data.copy()

--- a/backend/app/repositories/ai_repository.py
+++ b/backend/app/repositories/ai_repository.py
@@ -1,6 +1,5 @@
 """AI Analysis repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -21,9 +20,9 @@ class AIRepository:
         project_id: UUID,
         professional_id: UUID,
         compatibility_score: float,
-        positive_factors: Optional[dict] = None,
-        negative_factors: Optional[dict] = None,
-        recommendation: Optional[str] = None,
+        positive_factors: dict | None = None,
+        negative_factors: dict | None = None,
+        recommendation: str | None = None,
         model_version: str = "v1.0",
         analysis_date: str = "",
     ) -> AIAnalysis:
@@ -44,7 +43,7 @@ class AIRepository:
         self.db.refresh(db_analysis)
         return db_analysis
 
-    def get_by_id(self, analysis_id: UUID) -> Optional[AIAnalysis]:
+    def get_by_id(self, analysis_id: UUID) -> AIAnalysis | None:
         """Get AI analysis by ID (only non-deleted analyses)."""
         return (
             self.db.query(AIAnalysis)
@@ -55,11 +54,11 @@ class AIRepository:
     def update(
         self,
         analysis_id: UUID,
-        compatibility_score: Optional[float] = None,
-        positive_factors: Optional[dict] = None,
-        negative_factors: Optional[dict] = None,
-        recommendation: Optional[str] = None,
-    ) -> Optional[AIAnalysis]:
+        compatibility_score: float | None = None,
+        positive_factors: dict | None = None,
+        negative_factors: dict | None = None,
+        recommendation: str | None = None,
+    ) -> AIAnalysis | None:
         """Update AI analysis."""
         db_analysis = self.get_by_id(analysis_id)
         if not db_analysis:
@@ -143,7 +142,7 @@ class AIRepository:
 
     def get_analysis_by_project_and_professional(
         self, project_id: UUID, professional_id: UUID
-    ) -> Optional[AIAnalysis]:
+    ) -> AIAnalysis | None:
         """Get AI analysis by project and professional."""
         return (
             self.db.query(AIAnalysis)

--- a/backend/app/repositories/client_repository.py
+++ b/backend/app/repositories/client_repository.py
@@ -1,6 +1,5 @@
 """Client repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -39,7 +38,7 @@ class ClientRepository:
         self.db.refresh(db_profile)
         return db_profile
 
-    def get_by_id(self, profile_id: UUID) -> Optional[ClientProfile]:
+    def get_by_id(self, profile_id: UUID) -> ClientProfile | None:
         """Get client profile by ID (only non-deleted profiles)."""
         return (
             self.db.query(ClientProfile)
@@ -49,7 +48,7 @@ class ClientRepository:
             .first()
         )
 
-    def get_by_user_id(self, user_id: UUID) -> Optional[ClientProfile]:
+    def get_by_user_id(self, user_id: UUID) -> ClientProfile | None:
         """Get client profile by user ID (only non-deleted profiles)."""
         return (
             self.db.query(ClientProfile)
@@ -63,7 +62,7 @@ class ClientRepository:
 
     def update(
         self, profile_id: UUID, profile_data: ClientProfileUpdate
-    ) -> Optional[ClientProfile]:
+    ) -> ClientProfile | None:
         """Update client profile."""
         db_profile = self.get_by_id(profile_id)
         if not db_profile:
@@ -109,7 +108,7 @@ class ClientRepository:
 
     def update_rating(
         self, profile_id: UUID, average_rating: float, total_reviews: int
-    ) -> Optional[ClientProfile]:
+    ) -> ClientProfile | None:
         """Update client rating."""
         db_profile = self.get_by_id(profile_id)
         if not db_profile:
@@ -153,7 +152,7 @@ class ClientRepository:
 
     def update_link(
         self, link_id: UUID, link_update: ClientLinkUpdate
-    ) -> Optional[ClientLink]:
+    ) -> ClientLink | None:
         """Update a social link."""
         db_link = (
             self.db.query(ClientLink)

--- a/backend/app/repositories/professional_repository.py
+++ b/backend/app/repositories/professional_repository.py
@@ -1,6 +1,5 @@
 """Professional repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -44,7 +43,7 @@ class ProfessionalRepository:
         self.db.refresh(db_profile)
         return db_profile
 
-    def get_by_id(self, profile_id: UUID) -> Optional[ProfessionalProfile]:
+    def get_by_id(self, profile_id: UUID) -> ProfessionalProfile | None:
         """Get professional profile by ID (only non-deleted profiles)."""
         return (
             self.db.query(ProfessionalProfile)
@@ -57,7 +56,7 @@ class ProfessionalRepository:
             .first()
         )
 
-    def get_by_user_id(self, user_id: UUID) -> Optional[ProfessionalProfile]:
+    def get_by_user_id(self, user_id: UUID) -> ProfessionalProfile | None:
         """Get professional profile by user ID (only non-deleted profiles)."""
         return (
             self.db.query(ProfessionalProfile)
@@ -72,7 +71,7 @@ class ProfessionalRepository:
 
     def update(
         self, profile_id: UUID, profile_data: ProfessionalProfileUpdate
-    ) -> Optional[ProfessionalProfile]:
+    ) -> ProfessionalProfile | None:
         """Update professional profile."""
         db_profile = self.get_by_id(profile_id)
         if not db_profile:
@@ -118,7 +117,7 @@ class ProfessionalRepository:
 
     def update_rating(
         self, profile_id: UUID, average_rating: float, total_reviews: int
-    ) -> Optional[ProfessionalProfile]:
+    ) -> ProfessionalProfile | None:
         """Update professional rating."""
         db_profile = self.get_by_id(profile_id)
         if not db_profile:
@@ -135,9 +134,9 @@ class ProfessionalRepository:
         professional_id: UUID,
         skill_id: UUID,
         proficiency_level: int,
-        years_experience: Optional[int] = None,
+        years_experience: int | None = None,
         certified: bool = False,
-    ) -> Optional[ProfessionalSkill]:
+    ) -> ProfessionalSkill | None:
         """Add a skill to professional profile."""
         db_skill = ProfessionalSkill(
             professional_id=professional_id,
@@ -203,7 +202,7 @@ class ProfessionalRepository:
 
     def update_link(
         self, link_id: UUID, link_update: ProfessionalLinkUpdate
-    ) -> Optional[ProfessionalLink]:
+    ) -> ProfessionalLink | None:
         """Update a social link."""
         db_link = (
             self.db.query(ProfessionalLink)

--- a/backend/app/repositories/project_repository.py
+++ b/backend/app/repositories/project_repository.py
@@ -1,6 +1,5 @@
 """Project repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -33,7 +32,7 @@ class ProjectRepository:
         self.db.refresh(db_project)
         return db_project
 
-    def get_by_id(self, project_id: UUID) -> Optional[Project]:
+    def get_by_id(self, project_id: UUID) -> Project | None:
         """Get project by ID (only non-deleted projects)."""
         return (
             self.db.query(Project)
@@ -44,9 +43,7 @@ class ProjectRepository:
             .first()
         )
 
-    def update(
-        self, project_id: UUID, project_data: ProjectUpdate
-    ) -> Optional[Project]:
+    def update(self, project_id: UUID, project_data: ProjectUpdate) -> Project | None:
         """Update project."""
         db_project = self.get_by_id(project_id)
         if not db_project:
@@ -144,7 +141,7 @@ class ProjectRepository:
 
     def assign_professional(
         self, project_id: UUID, professional_id: UUID
-    ) -> Optional[Project]:
+    ) -> Project | None:
         """Assign a professional to a project."""
         db_project = self.get_by_id(project_id)
         if not db_project:
@@ -156,9 +153,7 @@ class ProjectRepository:
         self.db.refresh(db_project)
         return db_project
 
-    def update_status(
-        self, project_id: UUID, status: ProjectStatus
-    ) -> Optional[Project]:
+    def update_status(self, project_id: UUID, status: ProjectStatus) -> Project | None:
         """Update project status."""
         db_project = self.get_by_id(project_id)
         if not db_project:

--- a/backend/app/repositories/proposal_repository.py
+++ b/backend/app/repositories/proposal_repository.py
@@ -1,6 +1,5 @@
 """Proposal repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -33,7 +32,7 @@ class ProposalRepository:
         self.db.refresh(db_proposal)
         return db_proposal
 
-    def get_by_id(self, proposal_id: UUID) -> Optional[Proposal]:
+    def get_by_id(self, proposal_id: UUID) -> Proposal | None:
         """Get proposal by ID (only non-deleted proposals)."""
         return (
             self.db.query(Proposal)
@@ -43,7 +42,7 @@ class ProposalRepository:
 
     def update(
         self, proposal_id: UUID, proposal_data: ProposalUpdate
-    ) -> Optional[Proposal]:
+    ) -> Proposal | None:
         """Update proposal."""
         db_proposal = self.get_by_id(proposal_id)
         if not db_proposal:
@@ -130,7 +129,7 @@ class ProposalRepository:
             .all()
         )
 
-    def accept_proposal(self, proposal_id: UUID) -> Optional[Proposal]:
+    def accept_proposal(self, proposal_id: UUID) -> Proposal | None:
         """Accept a proposal."""
         db_proposal = self.get_by_id(proposal_id)
         if not db_proposal:
@@ -141,7 +140,7 @@ class ProposalRepository:
         self.db.refresh(db_proposal)
         return db_proposal
 
-    def reject_proposal(self, proposal_id: UUID) -> Optional[Proposal]:
+    def reject_proposal(self, proposal_id: UUID) -> Proposal | None:
         """Reject a proposal."""
         db_proposal = self.get_by_id(proposal_id)
         if not db_proposal:
@@ -152,7 +151,7 @@ class ProposalRepository:
         self.db.refresh(db_proposal)
         return db_proposal
 
-    def update_ai_score(self, proposal_id: UUID, ai_score: float) -> Optional[Proposal]:
+    def update_ai_score(self, proposal_id: UUID, ai_score: float) -> Proposal | None:
         """Update proposal AI score."""
         db_proposal = self.get_by_id(proposal_id)
         if not db_proposal:
@@ -165,14 +164,15 @@ class ProposalRepository:
 
     def get_proposal_by_project_and_professional(
         self, project_id: UUID, professional_id: UUID
-    ) -> Optional[Proposal]:
-        """Get proposal by project and professional."""
+    ) -> Proposal | None:
+        """Get active proposal by project and professional (only SUBMITTED status)."""
         return (
             self.db.query(Proposal)
             .filter(
                 and_(
                     Proposal.project_id == project_id,
                     Proposal.professional_id == professional_id,
+                    Proposal.status == ProposalStatus.SUBMITTED,
                     Proposal.deleted_at.is_(None),
                 )
             )

--- a/backend/app/repositories/review_repository.py
+++ b/backend/app/repositories/review_repository.py
@@ -1,6 +1,5 @@
 """Review repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -33,7 +32,7 @@ class ReviewRepository:
         self.db.refresh(db_review)
         return db_review
 
-    def get_by_id(self, review_id: UUID) -> Optional[Review]:
+    def get_by_id(self, review_id: UUID) -> Review | None:
         """Get review by ID (only non-deleted reviews)."""
         return (
             self.db.query(Review)
@@ -41,7 +40,7 @@ class ReviewRepository:
             .first()
         )
 
-    def update(self, review_id: UUID, review_data: ReviewUpdate) -> Optional[Review]:
+    def update(self, review_id: UUID, review_data: ReviewUpdate) -> Review | None:
         """Update review."""
         db_review = self.get_by_id(review_id)
         if not db_review:
@@ -139,7 +138,7 @@ class ReviewRepository:
             .all()
         )
 
-    def get_average_rating_for_user(self, user_id: UUID) -> Optional[float]:
+    def get_average_rating_for_user(self, user_id: UUID) -> float | None:
         """Get average rating for a user."""
         from sqlalchemy import func
 
@@ -161,7 +160,7 @@ class ReviewRepository:
 
     def get_review_by_project_and_reviewer(
         self, project_id: UUID, reviewer_id: UUID
-    ) -> Optional[Review]:
+    ) -> Review | None:
         """Get review by project and reviewer."""
         return (
             self.db.query(Review)

--- a/backend/app/repositories/skill_repository.py
+++ b/backend/app/repositories/skill_repository.py
@@ -1,6 +1,5 @@
 """Skill repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -31,7 +30,7 @@ class SkillRepository:
         self.db.refresh(db_skill)
         return db_skill
 
-    def get_by_id(self, skill_id: UUID) -> Optional[Skill]:
+    def get_by_id(self, skill_id: UUID) -> Skill | None:
         """Get skill by ID (only non-deleted skills)."""
         return (
             self.db.query(Skill)
@@ -39,7 +38,7 @@ class SkillRepository:
             .first()
         )
 
-    def get_by_name(self, name: str) -> Optional[Skill]:
+    def get_by_name(self, name: str) -> Skill | None:
         """Get skill by name (only non-deleted skills)."""
         return (
             self.db.query(Skill)
@@ -47,7 +46,7 @@ class SkillRepository:
             .first()
         )
 
-    def update(self, skill_id: UUID, skill_data: SkillUpdate) -> Optional[Skill]:
+    def update(self, skill_id: UUID, skill_data: SkillUpdate) -> Skill | None:
         """Update skill."""
         db_skill = self.get_by_id(skill_id)
         if not db_skill:
@@ -113,7 +112,7 @@ class SkillRepository:
             .all()
         )
 
-    def activate_skill(self, skill_id: UUID) -> Optional[Skill]:
+    def activate_skill(self, skill_id: UUID) -> Skill | None:
         """Activate skill."""
         db_skill = self.get_by_id(skill_id)
         if not db_skill:
@@ -124,7 +123,7 @@ class SkillRepository:
         self.db.refresh(db_skill)
         return db_skill
 
-    def deactivate_skill(self, skill_id: UUID) -> Optional[Skill]:
+    def deactivate_skill(self, skill_id: UUID) -> Skill | None:
         """Deactivate skill."""
         db_skill = self.get_by_id(skill_id)
         if not db_skill:

--- a/backend/app/repositories/user_repository.py
+++ b/backend/app/repositories/user_repository.py
@@ -1,6 +1,5 @@
 """User repository for database operations."""
 
-from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import and_
@@ -33,7 +32,7 @@ class UserRepository:
         self.db.refresh(db_user)
         return db_user
 
-    def get_by_id(self, user_id: UUID) -> Optional[User]:
+    def get_by_id(self, user_id: UUID) -> User | None:
         """Get user by ID (only non-deleted users)."""
         return (
             self.db.query(User)
@@ -41,7 +40,7 @@ class UserRepository:
             .first()
         )
 
-    def get_by_email(self, email: str) -> Optional[User]:
+    def get_by_email(self, email: str) -> User | None:
         """Get user by email (only non-deleted users)."""
         return (
             self.db.query(User)
@@ -49,7 +48,7 @@ class UserRepository:
             .first()
         )
 
-    def update(self, user_id: UUID, user_data: UserUpdate) -> Optional[User]:
+    def update(self, user_id: UUID, user_data: UserUpdate) -> User | None:
         """Update user."""
         db_user = self.get_by_id(user_id)
         if not db_user:
@@ -93,7 +92,7 @@ class UserRepository:
 
         return query.count()
 
-    def activate_user(self, user_id: UUID) -> Optional[User]:
+    def activate_user(self, user_id: UUID) -> User | None:
         """Activate user."""
         db_user = self.get_by_id(user_id)
         if not db_user:
@@ -104,7 +103,7 @@ class UserRepository:
         self.db.refresh(db_user)
         return db_user
 
-    def deactivate_user(self, user_id: UUID) -> Optional[User]:
+    def deactivate_user(self, user_id: UUID) -> User | None:
         """Deactivate user."""
         db_user = self.get_by_id(user_id)
         if not db_user:

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -1,7 +1,5 @@
 """Authentication schemas."""
 
-from typing import Optional
-
 from pydantic import BaseModel, Field
 
 
@@ -17,9 +15,9 @@ class Token(BaseModel):
 class TokenData(BaseModel):
     """Token data schema."""
 
-    user_id: Optional[str] = None
-    email: Optional[str] = None
-    account_type: Optional[str] = None
+    user_id: str | None = None
+    email: str | None = None
+    account_type: str | None = None
 
 
 class UserLogin(BaseModel):

--- a/backend/app/schemas/client.py
+++ b/backend/app/schemas/client.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -16,7 +15,7 @@ class ClientLinkBase(BaseModel):
         description="Platform name (github, linkedin, twitter, website, other)",
     )
     url: str = Field(description="Link URL")
-    label: Optional[str] = Field(
+    label: str | None = Field(
         default=None, max_length=255, description="Optional custom label"
     )
 
@@ -30,9 +29,9 @@ class ClientLinkCreate(ClientLinkBase):
 class ClientLinkUpdate(BaseModel):
     """Update client link schema."""
 
-    platform: Optional[str] = Field(default=None, max_length=50)
-    url: Optional[str] = None
-    label: Optional[str] = Field(default=None, max_length=255)
+    platform: str | None = Field(default=None, max_length=50)
+    url: str | None = None
+    label: str | None = Field(default=None, max_length=255)
 
 
 class ClientLinkResponse(ClientLinkBase):
@@ -49,14 +48,12 @@ class ClientLinkResponse(ClientLinkBase):
 class ClientProfileBase(BaseModel):
     """Base client profile schema."""
 
-    company_name: Optional[str] = Field(default=None, max_length=255)
-    business_sector: Optional[str] = Field(default=None, max_length=100)
-    description: Optional[str] = Field(
+    company_name: str | None = Field(default=None, max_length=255)
+    business_sector: str | None = Field(default=None, max_length=100)
+    description: str | None = Field(
         default=None, description="Description of the company"
     )
-    bio: Optional[str] = Field(
-        default=None, description="About section for the company"
-    )
+    bio: str | None = Field(default=None, description="About section for the company")
 
 
 class ClientProfileCreate(ClientProfileBase):
@@ -68,10 +65,10 @@ class ClientProfileCreate(ClientProfileBase):
 class ClientProfileUpdate(BaseModel):
     """Update client profile schema."""
 
-    company_name: Optional[str] = Field(default=None, max_length=255)
-    business_sector: Optional[str] = Field(default=None, max_length=100)
-    description: Optional[str] = None
-    bio: Optional[str] = None
+    company_name: str | None = Field(default=None, max_length=255)
+    business_sector: str | None = Field(default=None, max_length=100)
+    description: str | None = None
+    bio: str | None = None
 
 
 class ClientProfileResponse(ClientProfileBase):
@@ -79,7 +76,7 @@ class ClientProfileResponse(ClientProfileBase):
 
     id: UUID
     user_id: UUID
-    average_rating: Optional[Decimal] = None
+    average_rating: Decimal | None = None
     total_reviews: int = 0
     links: list[ClientLinkResponse] = []
     created_at: datetime

--- a/backend/app/schemas/professional.py
+++ b/backend/app/schemas/professional.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -13,7 +12,7 @@ class ProfessionalSkillBase(BaseModel):
 
     skill_id: UUID
     proficiency_level: int = Field(ge=1, le=5, description="Proficiency level (1-5)")
-    years_experience: Optional[int] = Field(default=None, ge=0)
+    years_experience: int | None = Field(default=None, ge=0)
     certified: bool = Field(default=False)
 
 
@@ -26,9 +25,9 @@ class ProfessionalSkillCreate(ProfessionalSkillBase):
 class ProfessionalSkillUpdate(BaseModel):
     """Update professional skill schema."""
 
-    proficiency_level: Optional[int] = Field(default=None, ge=1, le=5)
-    years_experience: Optional[int] = Field(default=None, ge=0)
-    certified: Optional[bool] = None
+    proficiency_level: int | None = Field(default=None, ge=1, le=5)
+    years_experience: int | None = Field(default=None, ge=0)
+    certified: bool | None = None
 
 
 class ProfessionalSkillResponse(ProfessionalSkillBase):
@@ -50,7 +49,7 @@ class ProfessionalLinkBase(BaseModel):
         description="Platform name (github, linkedin, twitter, portfolio, other)",
     )
     url: str = Field(description="Link URL")
-    label: Optional[str] = Field(
+    label: str | None = Field(
         default=None, max_length=255, description="Optional custom label"
     )
 
@@ -64,9 +63,9 @@ class ProfessionalLinkCreate(ProfessionalLinkBase):
 class ProfessionalLinkUpdate(BaseModel):
     """Update professional link schema."""
 
-    platform: Optional[str] = Field(default=None, max_length=50)
-    url: Optional[str] = None
-    label: Optional[str] = Field(default=None, max_length=255)
+    platform: str | None = Field(default=None, max_length=50)
+    url: str | None = None
+    label: str | None = Field(default=None, max_length=255)
 
 
 class ProfessionalLinkResponse(ProfessionalLinkBase):
@@ -84,26 +83,26 @@ class ProfessionalProfileBase(BaseModel):
     """Base professional profile schema."""
 
     title: str = Field(max_length=255)
-    description: Optional[str] = None
-    bio: Optional[str] = Field(
+    description: str | None = None
+    bio: str | None = Field(
         default=None, description="About section for the professional"
     )
-    hourly_rate: Optional[Decimal] = Field(default=None, ge=0)
+    hourly_rate: Decimal | None = Field(default=None, ge=0)
 
 
 class ProfessionalProfileCreate(ProfessionalProfileBase):
     """Create professional profile schema."""
 
-    skills: Optional[list[ProfessionalSkillCreate]] = Field(default_factory=list)
+    skills: list[ProfessionalSkillCreate] | None = Field(default_factory=list)
 
 
 class ProfessionalProfileUpdate(BaseModel):
     """Update professional profile schema."""
 
-    title: Optional[str] = Field(default=None, max_length=255)
-    description: Optional[str] = None
-    bio: Optional[str] = None
-    hourly_rate: Optional[Decimal] = Field(default=None, ge=0)
+    title: str | None = Field(default=None, max_length=255)
+    description: str | None = None
+    bio: str | None = None
+    hourly_rate: Decimal | None = Field(default=None, ge=0)
 
 
 class ProfessionalProfileResponse(ProfessionalProfileBase):
@@ -111,7 +110,7 @@ class ProfessionalProfileResponse(ProfessionalProfileBase):
 
     id: UUID
     user_id: UUID
-    average_rating: Optional[Decimal] = None
+    average_rating: Decimal | None = None
     total_reviews: int = 0
     skills: list[ProfessionalSkillResponse] = []
     links: list[ProfessionalLinkResponse] = []

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -23,9 +23,9 @@ class ProjectBase(BaseModel):
 
     title: str = Field(max_length=255)
     description: str
-    requirements: Optional[dict[str, Any]] = None
-    budget: Optional[Decimal] = Field(default=None, ge=0)
-    deadline: Optional[datetime] = None
+    requirements: dict[str, Any] | None = None
+    budget: Decimal | None = Field(default=None, ge=0)
+    deadline: datetime | None = None
 
 
 class ProjectCreate(ProjectBase):
@@ -37,12 +37,12 @@ class ProjectCreate(ProjectBase):
 class ProjectUpdate(BaseModel):
     """Update project schema."""
 
-    title: Optional[str] = Field(default=None, max_length=255)
-    description: Optional[str] = None
-    requirements: Optional[dict[str, Any]] = None
-    budget: Optional[Decimal] = Field(default=None, ge=0)
-    deadline: Optional[datetime] = None
-    status: Optional[ProjectStatus] = None
+    title: str | None = Field(default=None, max_length=255)
+    description: str | None = None
+    requirements: dict[str, Any] | None = None
+    budget: Decimal | None = Field(default=None, ge=0)
+    deadline: datetime | None = None
+    status: ProjectStatus | None = None
 
 
 class ProjectResponse(ProjectBase):
@@ -50,14 +50,12 @@ class ProjectResponse(ProjectBase):
 
     id: UUID
     client_id: UUID
-    client_user_id: Optional[
-        UUID
-    ] = None  # User ID of the client who created the project
+    client_user_id: UUID | None = None  # User ID of the client who created the project
     status: ProjectStatus
-    selected_professional_id: Optional[UUID] = None
-    selected_professional_user_id: Optional[
-        UUID
-    ] = None  # User ID of the selected professional
+    selected_professional_id: UUID | None = None
+    selected_professional_user_id: UUID | None = (
+        None  # User ID of the selected professional
+    )
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/proposal.py
+++ b/backend/app/schemas/proposal.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -21,7 +20,7 @@ class ProposalBase(BaseModel):
     """Base proposal schema."""
 
     proposed_amount: Decimal = Field(ge=0)
-    estimated_days: Optional[int] = Field(default=None, ge=1)
+    estimated_days: int | None = Field(default=None, ge=1)
     description: str
 
 
@@ -34,10 +33,10 @@ class ProposalCreate(ProposalBase):
 class ProposalUpdate(BaseModel):
     """Update proposal schema."""
 
-    proposed_amount: Optional[Decimal] = Field(default=None, ge=0)
-    estimated_days: Optional[int] = Field(default=None, ge=1)
-    description: Optional[str] = None
-    status: Optional[ProposalStatus] = None
+    proposed_amount: Decimal | None = Field(default=None, ge=0)
+    estimated_days: int | None = Field(default=None, ge=1)
+    description: str | None = None
+    status: ProposalStatus | None = None
 
 
 class ProposalResponse(ProposalBase):
@@ -47,7 +46,7 @@ class ProposalResponse(ProposalBase):
     project_id: UUID
     professional_id: UUID
     status: ProposalStatus
-    ai_score: Optional[Decimal] = None
+    ai_score: Decimal | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/review.py
+++ b/backend/app/schemas/review.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -19,7 +18,7 @@ class ReviewBase(BaseModel):
     """Base review schema."""
 
     rating: int = Field(ge=1, le=5, description="Rating (1-5)")
-    comment: Optional[str] = None
+    comment: str | None = None
     review_type: ReviewType
 
 
@@ -33,8 +32,8 @@ class ReviewCreate(ReviewBase):
 class ReviewUpdate(BaseModel):
     """Update review schema."""
 
-    rating: Optional[int] = Field(default=None, ge=1, le=5)
-    comment: Optional[str] = None
+    rating: int | None = Field(default=None, ge=1, le=5)
+    comment: str | None = None
 
 
 class ReviewResponse(ReviewBase):

--- a/backend/app/schemas/skill.py
+++ b/backend/app/schemas/skill.py
@@ -1,7 +1,6 @@
 """Skill schemas."""
 
 from datetime import datetime
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -12,7 +11,7 @@ class SkillBase(BaseModel):
 
     name: str = Field(max_length=100)
     category: str = Field(max_length=50)
-    description: Optional[str] = None
+    description: str | None = None
 
 
 class SkillCreate(SkillBase):
@@ -24,10 +23,10 @@ class SkillCreate(SkillBase):
 class SkillUpdate(BaseModel):
     """Update skill schema."""
 
-    name: Optional[str] = Field(default=None, max_length=100)
-    category: Optional[str] = Field(default=None, max_length=50)
-    description: Optional[str] = None
-    active: Optional[bool] = None
+    name: str | None = Field(default=None, max_length=100)
+    category: str | None = Field(default=None, max_length=50)
+    description: str | None = None
+    active: bool | None = None
 
 
 class SkillResponse(SkillBase):

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -1,7 +1,6 @@
 """User schemas."""
 
 from datetime import datetime
-from typing import Optional
 from uuid import UUID
 
 from pydantic import BaseModel, EmailStr, Field, field_serializer
@@ -16,7 +15,7 @@ class UserBase(BaseModel):
     full_name: str = Field(
         ..., min_length=1, max_length=255, description="User full name"
     )
-    phone: Optional[str] = Field(None, max_length=20, description="User phone number")
+    phone: str | None = Field(None, max_length=20, description="User phone number")
     account_type: AccountType = Field(..., description="User account type")
 
 
@@ -29,9 +28,9 @@ class UserCreate(UserBase):
 class UserUpdate(BaseModel):
     """User update schema."""
 
-    full_name: Optional[str] = Field(None, min_length=1, max_length=255)
-    phone: Optional[str] = Field(None, max_length=20)
-    active: Optional[bool] = None
+    full_name: str | None = Field(None, min_length=1, max_length=255)
+    phone: str | None = Field(None, max_length=20)
+    active: bool | None = None
 
 
 class UserResponse(UserBase):
@@ -41,7 +40,7 @@ class UserResponse(UserBase):
     active: bool
     created_at: datetime
     updated_at: datetime
-    deleted_at: Optional[datetime] = None
+    deleted_at: datetime | None = None
 
     @field_serializer("id")
     def serialize_id(self, value: UUID, _info):

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -204,38 +204,38 @@ class AIService:
                 project.description, professional.description
             )
             if description_score > 70:
-                positive_factors[
-                    "description_match"
-                ] = f"Excellent semantic match ({description_score:.1f}%)"
+                positive_factors["description_match"] = (
+                    f"Excellent semantic match ({description_score:.1f}%)"
+                )
             elif description_score > 50:
-                positive_factors[
-                    "description_match"
-                ] = f"Good semantic match ({description_score:.1f}%)"
+                positive_factors["description_match"] = (
+                    f"Good semantic match ({description_score:.1f}%)"
+                )
             else:
-                negative_factors[
-                    "description_mismatch"
-                ] = f"Low description match ({description_score:.1f}%)"
+                negative_factors["description_mismatch"] = (
+                    f"Low description match ({description_score:.1f}%)"
+                )
 
         # Component 2: Skills semantic match (30% weight)
         skills_score, matched_skills = await self._calculate_skills_semantic_match(
             project, professional_skills
         )
         if matched_skills:
-            positive_factors[
-                "matched_skills"
-            ] = f"Matched skills: {', '.join(matched_skills[:5])}"
+            positive_factors["matched_skills"] = (
+                f"Matched skills: {', '.join(matched_skills[:5])}"
+            )
         if skills_score > 70:
-            positive_factors[
-                "skills_match"
-            ] = f"Strong skills match ({skills_score:.1f}%)"
+            positive_factors["skills_match"] = (
+                f"Strong skills match ({skills_score:.1f}%)"
+            )
         elif skills_score > 50:
-            positive_factors[
-                "skills_match"
-            ] = f"Moderate skills match ({skills_score:.1f}%)"
+            positive_factors["skills_match"] = (
+                f"Moderate skills match ({skills_score:.1f}%)"
+            )
         else:
-            negative_factors[
-                "skills_mismatch"
-            ] = f"Weak skills match ({skills_score:.1f}%)"
+            negative_factors["skills_mismatch"] = (
+                f"Weak skills match ({skills_score:.1f}%)"
+            )
 
         # Component 3: Experience/Rating (20% weight)
         experience_score = 50.0
@@ -253,9 +253,9 @@ class AIService:
         review_score = 0.0
         if professional.total_reviews >= 10:
             review_score = min((professional.total_reviews / 50) * 100, 100)
-            positive_factors[
-                "reviews"
-            ] = f"{professional.total_reviews} reviews (experienced professional)"
+            positive_factors["reviews"] = (
+                f"{professional.total_reviews} reviews (experienced professional)"
+            )
 
         # Weighted final score
         final_score = (
@@ -290,9 +290,9 @@ class AIService:
         if professional_skills:
             skill_bonus = min(len(professional_skills) * 2, 20)
             base_score += skill_bonus
-            positive_factors[
-                "skills_count"
-            ] = f"Has {len(professional_skills)} skills (+{skill_bonus} points)"
+            positive_factors["skills_count"] = (
+                f"Has {len(professional_skills)} skills (+{skill_bonus} points)"
+            )
 
             # Factor 2: High proficiency levels (up to +10 points)
             avg_proficiency = sum(
@@ -301,18 +301,18 @@ class AIService:
             if avg_proficiency >= 4:
                 proficiency_bonus = 10
                 base_score += proficiency_bonus
-                positive_factors[
-                    "proficiency"
-                ] = f"High average proficiency ({avg_proficiency:.1f}/5) (+{proficiency_bonus} points)"
+                positive_factors["proficiency"] = (
+                    f"High average proficiency ({avg_proficiency:.1f}/5) (+{proficiency_bonus} points)"
+                )
 
             # Factor 3: Certified skills (up to +10 points)
             certified_count = sum(1 for skill in professional_skills if skill.certified)
             if certified_count > 0:
                 cert_bonus = min(certified_count * 5, 10)
                 base_score += cert_bonus
-                positive_factors[
-                    "certifications"
-                ] = f"{certified_count} certified skills (+{cert_bonus} points)"
+                positive_factors["certifications"] = (
+                    f"{certified_count} certified skills (+{cert_bonus} points)"
+                )
         else:
             negative_factors["no_skills"] = "No skills listed (-10 points)"
             base_score -= 10
@@ -323,29 +323,29 @@ class AIService:
             if rating >= 4.5:
                 rating_bonus = 15
                 base_score += rating_bonus
-                positive_factors[
-                    "rating"
-                ] = f"Excellent rating ({rating:.1f}/5) (+{rating_bonus} points)"
+                positive_factors["rating"] = (
+                    f"Excellent rating ({rating:.1f}/5) (+{rating_bonus} points)"
+                )
             elif rating >= 4.0:
                 rating_bonus = 10
                 base_score += rating_bonus
-                positive_factors[
-                    "rating"
-                ] = f"Good rating ({rating:.1f}/5) (+{rating_bonus} points)"
+                positive_factors["rating"] = (
+                    f"Good rating ({rating:.1f}/5) (+{rating_bonus} points)"
+                )
             elif rating < 3.0:
                 rating_penalty = 10
                 base_score -= rating_penalty
-                negative_factors[
-                    "low_rating"
-                ] = f"Low rating ({rating:.1f}/5) (-{rating_penalty} points)"
+                negative_factors["low_rating"] = (
+                    f"Low rating ({rating:.1f}/5) (-{rating_penalty} points)"
+                )
 
         # Factor 5: Number of reviews (up to +5 points)
         if professional.total_reviews >= 10:
             review_bonus = 5
             base_score += review_bonus
-            positive_factors[
-                "reviews"
-            ] = f"{professional.total_reviews} reviews (+{review_bonus} points)"
+            positive_factors["reviews"] = (
+                f"{professional.total_reviews} reviews (+{review_bonus} points)"
+            )
 
         # Ensure score is between 0 and 100
         final_score = max(0.0, min(100.0, base_score))

--- a/backend/app/services/client_service.py
+++ b/backend/app/services/client_service.py
@@ -1,6 +1,5 @@
 """Client service."""
 
-from typing import Optional
 from uuid import UUID
 
 from app.models.client import ClientLink, ClientProfile
@@ -32,17 +31,17 @@ class ClientService:
         # Create profile
         return self.client_repository.create(user_id, profile_data)
 
-    async def get_profile_by_id(self, profile_id: UUID) -> Optional[ClientProfile]:
+    async def get_profile_by_id(self, profile_id: UUID) -> ClientProfile | None:
         """Get client profile by ID."""
         return self.client_repository.get_by_id(profile_id)
 
-    async def get_profile_by_user_id(self, user_id: UUID) -> Optional[ClientProfile]:
+    async def get_profile_by_user_id(self, user_id: UUID) -> ClientProfile | None:
         """Get client profile by user ID."""
         return self.client_repository.get_by_user_id(user_id)
 
     async def update_profile(
         self, profile_id: UUID, profile_data: ClientProfileUpdate
-    ) -> Optional[ClientProfile]:
+    ) -> ClientProfile | None:
         """Update client profile."""
         return self.client_repository.update(profile_id, profile_data)
 
@@ -68,7 +67,7 @@ class ClientService:
 
     async def update_rating(
         self, profile_id: UUID, average_rating: float, total_reviews: int
-    ) -> Optional[ClientProfile]:
+    ) -> ClientProfile | None:
         """Update client rating."""
         return self.client_repository.update_rating(
             profile_id, average_rating, total_reviews
@@ -82,7 +81,7 @@ class ClientService:
 
     async def update_link(
         self, link_id: UUID, link_update: ClientLinkUpdate
-    ) -> Optional[ClientLink]:
+    ) -> ClientLink | None:
         """Update a social link."""
         return self.client_repository.update_link(link_id, link_update)
 

--- a/backend/app/services/email_service.py
+++ b/backend/app/services/email_service.py
@@ -1,7 +1,5 @@
 """Email Service using Resend API."""
 
-from typing import Optional
-
 import resend
 
 from app.core.config import settings
@@ -26,8 +24,8 @@ class EmailService:
         to: list[str],
         subject: str,
         html: str,
-        from_email: Optional[str] = None,
-        from_name: Optional[str] = None,
+        from_email: str | None = None,
+        from_name: str | None = None,
     ) -> dict:
         """
         Send email using Resend.

--- a/backend/app/services/embedding_service.py
+++ b/backend/app/services/embedding_service.py
@@ -3,7 +3,6 @@
 import asyncio
 import hashlib
 import logging
-from typing import Optional
 
 import httpx
 import numpy as np
@@ -29,7 +28,7 @@ class EmbeddingService:
                 "Hugging Face API key not configured. Embeddings will not be available."
             )
 
-    async def embed_text(self, text: str) -> Optional[list[float]]:
+    async def embed_text(self, text: str) -> list[float] | None:
         """
         Generate embedding vector for text using Hugging Face API.
 
@@ -104,7 +103,7 @@ class EmbeddingService:
         logger.error("Max retries exceeded for embedding generation")
         return None
 
-    async def embed_texts(self, texts: list[str]) -> list[Optional[list[float]]]:
+    async def embed_texts(self, texts: list[str]) -> list[list[float] | None]:
         """
         Generate embeddings for multiple texts in parallel.
 
@@ -117,9 +116,7 @@ class EmbeddingService:
         tasks = [self.embed_text(text) for text in texts]
         return await asyncio.gather(*tasks)
 
-    def cosine_similarity(
-        self, vec1: list[float], vec2: list[float]
-    ) -> Optional[float]:
+    def cosine_similarity(self, vec1: list[float], vec2: list[float]) -> float | None:
         """
         Calculate cosine similarity between two vectors.
 

--- a/backend/app/services/professional_service.py
+++ b/backend/app/services/professional_service.py
@@ -1,6 +1,5 @@
 """Professional service."""
 
-from typing import Optional
 from uuid import UUID
 
 from app.models.professional import (
@@ -61,21 +60,17 @@ class ProfessionalService:
 
         return profile
 
-    async def get_profile_by_id(
-        self, profile_id: UUID
-    ) -> Optional[ProfessionalProfile]:
+    async def get_profile_by_id(self, profile_id: UUID) -> ProfessionalProfile | None:
         """Get professional profile by ID."""
         return self.professional_repository.get_by_id(profile_id)
 
-    async def get_profile_by_user_id(
-        self, user_id: UUID
-    ) -> Optional[ProfessionalProfile]:
+    async def get_profile_by_user_id(self, user_id: UUID) -> ProfessionalProfile | None:
         """Get professional profile by user ID."""
         return self.professional_repository.get_by_user_id(user_id)
 
     async def update_profile(
         self, profile_id: UUID, profile_data: ProfessionalProfileUpdate
-    ) -> Optional[ProfessionalProfile]:
+    ) -> ProfessionalProfile | None:
         """Update professional profile."""
         return self.professional_repository.update(profile_id, profile_data)
 
@@ -95,7 +90,7 @@ class ProfessionalService:
 
     async def add_skill(
         self, professional_id: UUID, skill_data: ProfessionalSkillCreate
-    ) -> Optional[ProfessionalSkill]:
+    ) -> ProfessionalSkill | None:
         """Add a skill to professional profile."""
         # Verify professional exists
         professional = self.professional_repository.get_by_id(professional_id)
@@ -131,7 +126,7 @@ class ProfessionalService:
 
     async def update_rating(
         self, profile_id: UUID, average_rating: float, total_reviews: int
-    ) -> Optional[ProfessionalProfile]:
+    ) -> ProfessionalProfile | None:
         """Update professional rating."""
         return self.professional_repository.update_rating(
             profile_id, average_rating, total_reviews
@@ -145,7 +140,7 @@ class ProfessionalService:
 
     async def update_link(
         self, link_id: UUID, link_update: ProfessionalLinkUpdate
-    ) -> Optional[ProfessionalLink]:
+    ) -> ProfessionalLink | None:
         """Update a social link."""
         return self.professional_repository.update_link(link_id, link_update)
 

--- a/backend/app/services/project_service.py
+++ b/backend/app/services/project_service.py
@@ -1,6 +1,5 @@
 """Project service."""
 
-from typing import Optional
 from uuid import UUID
 
 from app.models.project import Project, ProjectStatus
@@ -35,13 +34,13 @@ class ProjectService:
 
         return self.project_repository.create(client_id, project_data)
 
-    async def get_project_by_id(self, project_id: UUID) -> Optional[Project]:
+    async def get_project_by_id(self, project_id: UUID) -> Project | None:
         """Get project by ID."""
         return self.project_repository.get_by_id(project_id)
 
     async def update_project(
         self, project_id: UUID, project_data: ProjectUpdate
-    ) -> Optional[Project]:
+    ) -> Project | None:
         """Update project."""
         return self.project_repository.update(project_id, project_data)
 
@@ -87,7 +86,7 @@ class ProjectService:
 
     async def assign_professional(
         self, project_id: UUID, professional_id: UUID
-    ) -> Optional[Project]:
+    ) -> Project | None:
         """Assign a professional to a project."""
         # Verify project exists
         project = self.project_repository.get_by_id(project_id)
@@ -109,7 +108,7 @@ class ProjectService:
 
     async def update_status(
         self, project_id: UUID, status: ProjectStatus
-    ) -> Optional[Project]:
+    ) -> Project | None:
         """Update project status."""
         # Verify project exists
         project = self.project_repository.get_by_id(project_id)
@@ -131,10 +130,52 @@ class ProjectService:
 
         return self.project_repository.update_status(project_id, status)
 
-    async def complete_project(self, project_id: UUID) -> Optional[Project]:
+    async def complete_project(self, project_id: UUID) -> Project | None:
         """Mark project as completed."""
         return await self.update_status(project_id, ProjectStatus.COMPLETED)
 
-    async def cancel_project(self, project_id: UUID) -> Optional[Project]:
+    async def cancel_project(self, project_id: UUID) -> Project | None:
         """Mark project as cancelled."""
         return await self.update_status(project_id, ProjectStatus.CANCELLED)
+
+    async def start_project(
+        self, project_id: UUID, professional_id: UUID
+    ) -> Project | None:
+        """Start project (professional only - OPEN -> IN_PROGRESS)."""
+        # Verify project exists
+        project = self.project_repository.get_by_id(project_id)
+        if not project:
+            raise ValueError("Project not found")
+
+        # Verify professional is assigned to this project
+        if project.selected_professional_id != professional_id:
+            raise ValueError("Only the assigned professional can start this project")
+
+        # Verify project is in OPEN status
+        if project.status != ProjectStatus.OPEN:
+            raise ValueError(
+                f"Project must be OPEN to start. Current status: {project.status}"
+            )
+
+        return await self.update_status(project_id, ProjectStatus.IN_PROGRESS)
+
+    async def complete_project_by_professional(
+        self, project_id: UUID, professional_id: UUID
+    ) -> Project | None:
+        """Complete project (professional only - IN_PROGRESS -> COMPLETED)."""
+        # Verify project exists
+        project = self.project_repository.get_by_id(project_id)
+        if not project:
+            raise ValueError("Project not found")
+
+        # Verify professional is assigned to this project
+        if project.selected_professional_id != professional_id:
+            raise ValueError("Only the assigned professional can complete this project")
+
+        # Verify project is in IN_PROGRESS status
+        if project.status != ProjectStatus.IN_PROGRESS:
+            raise ValueError(
+                f"Project must be IN_PROGRESS to complete. Current status: {project.status}"
+            )
+
+        return await self.update_status(project_id, ProjectStatus.COMPLETED)

--- a/backend/app/services/proposal_service.py
+++ b/backend/app/services/proposal_service.py
@@ -1,6 +1,5 @@
 """Proposal service."""
 
-from typing import Optional
 from uuid import UUID
 
 from app.models.project import ProjectStatus
@@ -56,13 +55,13 @@ class ProposalService:
 
         return self.proposal_repository.create(professional_id, proposal_data)
 
-    async def get_proposal_by_id(self, proposal_id: UUID) -> Optional[Proposal]:
+    async def get_proposal_by_id(self, proposal_id: UUID) -> Proposal | None:
         """Get proposal by ID."""
         return self.proposal_repository.get_by_id(proposal_id)
 
     async def update_proposal(
         self, proposal_id: UUID, proposal_data: ProposalUpdate
-    ) -> Optional[Proposal]:
+    ) -> Proposal | None:
         """Update proposal."""
         # Verify proposal exists
         proposal = self.proposal_repository.get_by_id(proposal_id)
@@ -119,7 +118,7 @@ class ProposalService:
             status, skip=skip, limit=limit
         )
 
-    async def accept_proposal(self, proposal_id: UUID) -> Optional[Proposal]:
+    async def accept_proposal(self, proposal_id: UUID) -> Proposal | None:
         """Accept a proposal and assign professional to project."""
         # Verify proposal exists
         proposal = self.proposal_repository.get_by_id(proposal_id)
@@ -159,7 +158,7 @@ class ProposalService:
 
         return accepted_proposal
 
-    async def reject_proposal(self, proposal_id: UUID) -> Optional[Proposal]:
+    async def reject_proposal(self, proposal_id: UUID) -> Proposal | None:
         """Reject a proposal."""
         # Verify proposal exists
         proposal = self.proposal_repository.get_by_id(proposal_id)
@@ -174,6 +173,6 @@ class ProposalService:
 
     async def update_ai_score(
         self, proposal_id: UUID, ai_score: float
-    ) -> Optional[Proposal]:
+    ) -> Proposal | None:
         """Update proposal AI score."""
         return self.proposal_repository.update_ai_score(proposal_id, ai_score)

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -1,6 +1,5 @@
 """Review service."""
 
-from typing import Optional
 from uuid import UUID
 
 from app.models.project import ProjectStatus
@@ -115,13 +114,13 @@ class ReviewService:
                     client.id, average_rating, total_reviews
                 )
 
-    async def get_review_by_id(self, review_id: UUID) -> Optional[Review]:
+    async def get_review_by_id(self, review_id: UUID) -> Review | None:
         """Get review by ID."""
         return self.review_repository.get_by_id(review_id)
 
     async def update_review(
         self, review_id: UUID, review_data: ReviewUpdate
-    ) -> Optional[Review]:
+    ) -> Review | None:
         """Update review."""
         review = self.review_repository.update(review_id, review_data)
 
@@ -185,6 +184,6 @@ class ReviewService:
             review_type, skip=skip, limit=limit
         )
 
-    async def get_average_rating_for_user(self, user_id: UUID) -> Optional[float]:
+    async def get_average_rating_for_user(self, user_id: UUID) -> float | None:
         """Get average rating for a user."""
         return self.review_repository.get_average_rating_for_user(user_id)

--- a/backend/app/services/skill_service.py
+++ b/backend/app/services/skill_service.py
@@ -1,6 +1,5 @@
 """Skill service."""
 
-from typing import Optional
 from uuid import UUID
 
 from app.models.skill import Skill
@@ -24,17 +23,17 @@ class SkillService:
 
         return self.skill_repository.create(skill_data)
 
-    async def get_skill_by_id(self, skill_id: UUID) -> Optional[Skill]:
+    async def get_skill_by_id(self, skill_id: UUID) -> Skill | None:
         """Get skill by ID."""
         return self.skill_repository.get_by_id(skill_id)
 
-    async def get_skill_by_name(self, name: str) -> Optional[Skill]:
+    async def get_skill_by_name(self, name: str) -> Skill | None:
         """Get skill by name."""
         return self.skill_repository.get_by_name(name)
 
     async def update_skill(
         self, skill_id: UUID, skill_data: SkillUpdate
-    ) -> Optional[Skill]:
+    ) -> Skill | None:
         """Update skill."""
         # If updating name, check for duplicates
         if skill_data.name:
@@ -68,7 +67,7 @@ class SkillService:
         """Get active skills."""
         return self.skill_repository.get_active_skills(skip=skip, limit=limit)
 
-    async def activate_skill(self, skill_id: UUID) -> Optional[Skill]:
+    async def activate_skill(self, skill_id: UUID) -> Skill | None:
         """Activate skill."""
         skill = self.skill_repository.get_by_id(skill_id)
         if not skill:
@@ -76,7 +75,7 @@ class SkillService:
 
         return self.skill_repository.activate_skill(skill_id)
 
-    async def deactivate_skill(self, skill_id: UUID) -> Optional[Skill]:
+    async def deactivate_skill(self, skill_id: UUID) -> Skill | None:
         """Deactivate skill."""
         skill = self.skill_repository.get_by_id(skill_id)
         if not skill:

--- a/backend/app/services/storage_service.py
+++ b/backend/app/services/storage_service.py
@@ -3,7 +3,6 @@
 import mimetypes
 import uuid
 from datetime import datetime
-from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -36,7 +35,7 @@ class StorageService:
         file_content: bytes,
         filename: str,
         folder: str = "uploads",
-        content_type: Optional[str] = None,
+        content_type: str | None = None,
     ) -> dict:
         """
         Upload file to S3.

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -1,6 +1,5 @@
 """User service."""
 
-from typing import Optional
 from uuid import UUID
 
 from app.core.exceptions import ConflictError, NotFoundError
@@ -34,7 +33,7 @@ class UserService:
 
         return UserResponse.model_validate(db_user)
 
-    def get_user_by_email(self, email: str) -> Optional[UserResponse]:
+    def get_user_by_email(self, email: str) -> UserResponse | None:
         """Get user by email."""
         db_user = self.user_repository.get_by_email(email)
         if not db_user:

--- a/backend/tests/test_project_status.py
+++ b/backend/tests/test_project_status.py
@@ -1,0 +1,166 @@
+"""Test project status management by professionals."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.factories import (
+    ProfessionalProfileFactory,
+    ProjectFactory,
+    set_sqlalchemy_session,
+)
+
+
+@pytest.fixture(scope="function")
+def db_session_with_factories(db_session):
+    """Set up database session with factory_boy."""
+    set_sqlalchemy_session(db_session)
+    yield db_session
+
+
+def test_professional_start_project(db_session_with_factories, client: TestClient):
+    """Test that assigned professional can start a project (OPEN -> IN_PROGRESS)."""
+    # Create professional and project
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        status="OPEN",
+        selected_professional_id=professional.id,
+    )
+    db_session_with_factories.commit()
+
+    response = client.patch(f"/api/v1/projects/{project.id}/start")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "IN_PROGRESS"
+    assert data["id"] == str(project.id)
+
+
+def test_professional_complete_project(db_session_with_factories, client: TestClient):
+    """Test that assigned professional can complete a project (IN_PROGRESS -> COMPLETED)."""
+    # Create professional and project in progress
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        status="IN_PROGRESS",
+        selected_professional_id=professional.id,
+    )
+    db_session_with_factories.commit()
+
+    response = client.patch(f"/api/v1/projects/{project.id}/complete-by-professional")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "COMPLETED"
+    assert data["id"] == str(project.id)
+
+
+def test_professional_cannot_start_unassigned_project(
+    db_session_with_factories, client: TestClient
+):
+    """Test that professional cannot start a project they are not assigned to."""
+    # Create professional and project with different professional assigned
+    _ = ProfessionalProfileFactory()  # Current user (not assigned)
+    other_professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        status="OPEN",
+        selected_professional_id=other_professional.id,
+    )
+    db_session_with_factories.commit()
+
+    response = client.patch(f"/api/v1/projects/{project.id}/start")
+
+    # Should fail because professional is not assigned to this project
+    assert response.status_code == 400
+
+
+def test_professional_cannot_complete_unassigned_project(
+    db_session_with_factories, client: TestClient
+):
+    """Test that professional cannot complete a project they are not assigned to."""
+    # Create professional and project with different professional assigned
+    _ = ProfessionalProfileFactory()  # Current user (not assigned)
+    other_professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        status="IN_PROGRESS",
+        selected_professional_id=other_professional.id,
+    )
+    db_session_with_factories.commit()
+
+    response = client.patch(f"/api/v1/projects/{project.id}/complete-by-professional")
+
+    # Should fail because professional is not assigned to this project
+    assert response.status_code == 400
+
+
+def test_professional_cannot_start_non_open_project(
+    db_session_with_factories, client: TestClient
+):
+    """Test that professional cannot start a project that is not OPEN."""
+    # Create professional and project already in progress
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        status="IN_PROGRESS",
+        selected_professional_id=professional.id,
+    )
+    db_session_with_factories.commit()
+
+    response = client.patch(f"/api/v1/projects/{project.id}/start")
+
+    # Should fail because project is not OPEN
+    assert response.status_code == 400
+
+
+def test_professional_cannot_complete_non_in_progress_project(
+    db_session_with_factories, client: TestClient
+):
+    """Test that professional cannot complete a project that is not IN_PROGRESS."""
+    # Create professional and project still open
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        status="OPEN",
+        selected_professional_id=professional.id,
+    )
+    db_session_with_factories.commit()
+
+    response = client.patch(f"/api/v1/projects/{project.id}/complete-by-professional")
+
+    # Should fail because project is not IN_PROGRESS
+    assert response.status_code == 400
+
+
+def test_professional_workflow_full_cycle(
+    db_session_with_factories, client: TestClient
+):
+    """Test full workflow: professional applies, gets accepted, starts, and completes project."""
+    # Create professional and open project
+    _ = ProfessionalProfileFactory()  # Professional will be created via proposal
+    project = ProjectFactory(status="OPEN")
+    db_session_with_factories.commit()
+
+    # Professional submits proposal
+    proposal_response = client.post(
+        "/api/v1/proposals/",
+        json={
+            "project_id": str(project.id),
+            "proposed_amount": 15000.00,
+            "estimated_days": 30,
+            "description": "I can do this project",
+        },
+    )
+    assert proposal_response.status_code == 201
+    proposal_id = proposal_response.json()["id"]
+
+    # Client accepts proposal
+    accept_response = client.post(f"/api/v1/proposals/{proposal_id}/accept")
+    assert accept_response.status_code == 200
+
+    # Professional starts project
+    start_response = client.patch(f"/api/v1/projects/{project.id}/start")
+    assert start_response.status_code == 200
+    assert start_response.json()["status"] == "IN_PROGRESS"
+
+    # Professional completes project
+    complete_response = client.patch(
+        f"/api/v1/projects/{project.id}/complete-by-professional"
+    )
+    assert complete_response.status_code == 200
+    assert complete_response.json()["status"] == "COMPLETED"

--- a/backend/tests/test_proposals.py
+++ b/backend/tests/test_proposals.py
@@ -147,3 +147,46 @@ def test_proposal_only_for_open_projects(db_session_with_factories, client: Test
 
     # Should fail because project is not OPEN
     assert response.status_code in [400, 403]
+
+
+def test_create_proposal_after_rejection(db_session_with_factories, client: TestClient):
+    """Test that professional can submit new proposal after previous one was rejected."""
+    # Create professional and open project
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(status="OPEN")
+    db_session_with_factories.commit()
+
+    # Create first proposal and reject it
+    first_response = client.post(
+        "/api/v1/proposals/",
+        json={
+            "project_id": str(project.id),
+            "proposed_amount": 15000.00,
+            "estimated_days": 30,
+            "description": "First proposal",
+        },
+    )
+    assert first_response.status_code == 201
+    first_proposal_id = first_response.json()["id"]
+
+    # Reject first proposal
+    reject_response = client.post(f"/api/v1/proposals/{first_proposal_id}/reject")
+    assert reject_response.status_code == 200
+
+    # Try to submit second proposal - should succeed
+    second_response = client.post(
+        "/api/v1/proposals/",
+        json={
+            "project_id": str(project.id),
+            "proposed_amount": 12000.00,
+            "estimated_days": 25,
+            "description": "Second proposal after rejection",
+        },
+    )
+
+    assert second_response.status_code == 201
+    data = second_response.json()
+    assert data["project_id"] == str(project.id)
+    assert data["professional_id"] == str(professional.id)
+    assert data["proposed_amount"] == 12000.00
+    assert data["status"] == "SUBMITTED"

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -30,6 +30,7 @@ const ProjectDetailPage = () => {
   const [proposalDays, setProposalDays] = useState('')
   const [isSubmittingProposal, setIsSubmittingProposal] = useState(false)
   const [hasApplied, setHasApplied] = useState(false)
+  const [hasProfessionalProfile, setHasProfessionalProfile] = useState(false)
 
   const checkIfApplied = useCallback(async () => {
     if (!user || !id) return
@@ -37,15 +38,19 @@ const ProjectDetailPage = () => {
     try {
       const professionalProfile = await professionalService.getMyProfile()
       if (professionalProfile) {
+        setHasProfessionalProfile(true)
         const proposals = await proposalService.getProposals({
           project_id: id,
           professional_id: professionalProfile.id,
           limit: 1,
         })
         setHasApplied(proposals.items.length > 0)
+      } else {
+        setHasProfessionalProfile(false)
       }
     } catch (error) {
       // User might not have a professional profile
+      setHasProfessionalProfile(false)
       console.log('Could not check proposal status:', error)
     }
   }, [id, user])
@@ -164,12 +169,23 @@ const ProjectDetailPage = () => {
     if (!project) return
 
     try {
-      await projectService.updateProject(project.id, { status: newStatus })
+      // Use specific endpoints for professional status changes
+      if (newStatus === 'IN_PROGRESS') {
+        await projectService.startProject(project.id)
+      } else if (newStatus === 'COMPLETED') {
+        await projectService.completeProjectByProfessional(project.id)
+      } else {
+        // Fallback to updateProject for other status changes (if needed)
+        await projectService.updateProject(project.id, { status: newStatus })
+      }
       toast.success('Project status updated successfully!')
       loadProject()
     } catch (error) {
       console.error('Failed to update project status:', error)
-      toast.error('Failed to update project status')
+      const errorMessage = (error && typeof error === 'object' && 'response' in error &&
+        (error as { response?: { data?: { detail?: string } } }).response?.data?.detail) ||
+        'Failed to update project status'
+      toast.error(String(errorMessage))
     }
   }
 
@@ -203,6 +219,9 @@ const ProjectDetailPage = () => {
   // Check if professional can apply to project
   const canApplyToProject = () => {
     if (!project || !user) return false
+
+    // User must have a professional profile
+    if (!hasProfessionalProfile) return false
 
     // Project must be OPEN
     if (project.status !== 'OPEN') return false
@@ -531,7 +550,7 @@ const ProjectDetailPage = () => {
         </div>
       )}
 
-      {hasApplied && !canApplyToProject() && project.status === 'OPEN' && (
+      {hasProfessionalProfile && hasApplied && project.status === 'OPEN' && (
         <div className="card mb-6">
           <div className="card-content">
             <div className="text-center py-4">

--- a/frontend/src/services/projectService.ts
+++ b/frontend/src/services/projectService.ts
@@ -69,4 +69,14 @@ export const projectService = {
     const response = await apiClient.patch<Project>(`/projects/${id}/cancel`)
     return response.data
   },
+
+  async startProject(id: string): Promise<Project> {
+    const response = await apiClient.patch<Project>(`/projects/${id}/start`)
+    return response.data
+  },
+
+  async completeProjectByProfessional(id: string): Promise<Project> {
+    const response = await apiClient.patch<Project>(`/projects/${id}/complete-by-professional`)
+    return response.data
+  },
 }


### PR DESCRIPTION
This commit addresses multiple critical bugs reported in production:

**Bug 1: Professional status management (403 error)**
- Created new endpoints: PATCH /projects/{id}/start and /projects/{id}/complete-by-professional
- Added start_project() and complete_project_by_professional() methods to ProjectService
- Frontend now uses specific endpoints for professional status changes
- Professionals can now properly manage project status (OPEN → IN_PROGRESS → COMPLETED)

**Bug 2: Client proposal button visibility**
- Added hasProfessionalProfile state to track if user has professional profile
- Updated canApplyToProject() to check for professional profile before showing button
- Clients no longer see "Submit Proposal" button

**Bug 3: Multiple proposals after rejection**
- Modified get_proposal_by_project_and_professional() to filter only SUBMITTED status
- Professionals can now submit new proposals after previous ones were rejected/cancelled

**Bug 4: Incorrect "already submitted" message**
- Fixed condition to show message only for professionals who actually submitted
- Changed from hasApplied && !canApplyToProject() to hasProfessionalProfile && hasApplied

**Testing:**
- Added comprehensive test suite in test_project_status.py
- Added test_create_proposal_after_rejection() in test_proposals.py
- All tests follow factory_boy and faker patterns
- Ruff formatting applied to maintain code style consistency

**Verification:**
- Backend: ruff check and format passed
- Frontend: lint, type-check, and build passed successfully