### PR TITLE
fix: correct review permission check to compare user IDs

### DIFF
--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -55,11 +55,16 @@ class ReviewService:
                 f"Cannot review project that is not completed. Current status: {project.status}"
             )
 
-        # Verify reviewer is part of the project
-        if (
-            reviewer_id != project.client_id
-            and reviewer_id != project.selected_professional_id
-        ):
+        # Get user IDs from project relationships
+        client_user_id = project.client.user_id if project.client else None
+        professional_user_id = (
+            project.selected_professional.user_id
+            if project.selected_professional
+            else None
+        )
+
+        # Verify reviewer is part of the project (compare user_ids)
+        if reviewer_id != client_user_id and reviewer_id != professional_user_id:
             raise ValueError("You can only review projects you are part of")
 
         # Verify reviewer hasn't already reviewed this project
@@ -71,16 +76,16 @@ class ReviewService:
 
         # Validate review type matches project roles
         if review_data.review_type == ReviewType.CLIENT_TO_PROFESSIONAL:
-            if reviewer_id != project.client_id:
+            if reviewer_id != client_user_id:
                 raise ValueError("Only the client can review the professional")
-            if review_data.reviewed_id != project.selected_professional_id:
+            if review_data.reviewed_id != professional_user_id:
                 raise ValueError(
                     "You can only review the professional assigned to this project"
                 )
         elif review_data.review_type == ReviewType.PROFESSIONAL_TO_CLIENT:
-            if reviewer_id != project.selected_professional_id:
+            if reviewer_id != professional_user_id:
                 raise ValueError("Only the professional can review the client")
-            if review_data.reviewed_id != project.client_id:
+            if review_data.reviewed_id != client_user_id:
                 raise ValueError("You can only review the client of this project")
 
         # Create review

--- a/backend/tests/test_reviews.py
+++ b/backend/tests/test_reviews.py
@@ -260,3 +260,84 @@ def test_delete_review(db_session_with_factories, client: TestClient):
     # Verify review is deleted
     response = client.get(f"/api/v1/reviews/{review.id}")
     assert response.status_code == 404
+
+
+def test_both_parties_can_review_completed_project(
+    db_session_with_factories, client: TestClient
+):
+    """Test that both client and professional can review a completed project."""
+    # Create completed project with client and professional
+    client_profile = ClientProfileFactory()
+    professional = ProfessionalProfileFactory()
+    project = ProjectFactory(
+        client=client_profile,
+        selected_professional_id=professional.id,
+        status="COMPLETED",
+    )
+    db_session_with_factories.commit()
+
+    # Client reviews professional
+    client_review_response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(professional.user_id),
+            "rating": 5,
+            "comment": "Great work!",
+            "review_type": "client_to_professional",
+        },
+    )
+
+    assert client_review_response.status_code == 201
+    client_review_data = client_review_response.json()
+    assert client_review_data["reviewer_id"] == str(client_profile.user_id)
+    assert client_review_data["reviewed_id"] == str(professional.user_id)
+
+    # Professional reviews client
+    professional_review_response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(client_profile.user_id),
+            "rating": 4,
+            "comment": "Good client!",
+            "review_type": "professional_to_client",
+        },
+    )
+
+    assert professional_review_response.status_code == 201
+    professional_review_data = professional_review_response.json()
+    assert professional_review_data["reviewer_id"] == str(professional.user_id)
+    assert professional_review_data["reviewed_id"] == str(client_profile.user_id)
+
+
+def test_third_party_cannot_review_project(
+    db_session_with_factories, client: TestClient
+):
+    """Test that users not part of a project cannot review it."""
+    # Create completed project with client and professional
+    client_profile = ClientProfileFactory()
+    professional = ProfessionalProfileFactory()
+    _ = ProfessionalProfileFactory()  # Third party professional
+    project = ProjectFactory(
+        client=client_profile,
+        selected_professional_id=professional.id,
+        status="COMPLETED",
+    )
+    db_session_with_factories.commit()
+
+    # Third party tries to review
+    response = client.post(
+        "/api/v1/reviews/",
+        json={
+            "project_id": str(project.id),
+            "reviewed_id": str(professional.user_id),
+            "rating": 5,
+            "comment": "I'm not part of this project",
+            "review_type": "client_to_professional",
+        },
+    )
+
+    # Should fail because third party is not part of the project
+    assert response.status_code in [400, 403]
+    assert "part of" in response.json()["detail"].lower()


### PR DESCRIPTION
This commit fixes a critical bug where both clients and professionals were unable to leave reviews on completed projects, receiving the error "You can only review projects you are part of".

**Problem:**
The review service was incorrectly comparing:
- reviewer_id (user ID)
- project.client_id (ClientProfile ID)
- project.selected_professional_id (ProfessionalProfile ID)

These are different UUID types, so the comparison always failed.

**Solution:**
Updated review_service.py to extract user IDs from project relationships:
- project.client.user_id (client's user ID)
- project.selected_professional.user_id (professional's user ID)

Now correctly compares user_id with user_id, allowing both parties to leave reviews on completed projects.

**Testing:**
- Added test_both_parties_can_review_completed_project() Verifies both client and professional can review the same project
- Added test_third_party_cannot_review_project() Ensures users not involved in the project cannot review it
- All existing review tests still pass
- Backend: ruff check and format passed
- Frontend: lint, type-check, and build passed

**Files Changed:**
- backend/app/services/review_service.py: Fixed user ID comparison logic
- backend/tests/test_reviews.py: Added comprehensive permission tests