### PR TITLE
fix: serialize Decimal fields to float in profile responses

### DIFF
--- a/backend/app/schemas/client.py
+++ b/backend/app/schemas/client.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class ClientLinkBase(BaseModel):
@@ -83,3 +83,8 @@ class ClientProfileResponse(ClientProfileBase):
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer("average_rating")
+    def serialize_decimal_to_float(self, value: Decimal | None) -> float | None:
+        """Convert Decimal to float for JSON serialization."""
+        return float(value) if value is not None else None

--- a/backend/app/schemas/professional.py
+++ b/backend/app/schemas/professional.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from decimal import Decimal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_serializer
 
 
 class ProfessionalSkillBase(BaseModel):
@@ -118,3 +118,8 @@ class ProfessionalProfileResponse(ProfessionalProfileBase):
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+    @field_serializer("average_rating", "hourly_rate")
+    def serialize_decimal_to_float(self, value: Decimal | None) -> float | None:
+        """Convert Decimal to float for JSON serialization."""
+        return float(value) if value is not None else None


### PR DESCRIPTION
This commit fixes a TypeError in the frontend dashboard where averageRating.toFixed() was failing because the backend was returning Decimal values as strings instead of numbers.

**Problem:**
- Backend schemas used Decimal type for average_rating and hourly_rate
- Pydantic serializes Decimal as string by default in JSON
- Frontend expected number type to use .toFixed() method
- Error: "TypeError: l.averageRating.toFixed is not a function"

**Solution:**
Added @field_serializer decorators to convert Decimal to float:
- ProfessionalProfileResponse: average_rating, hourly_rate
- ClientProfileResponse: average_rating

Now these fields are serialized as JSON numbers, allowing JavaScript number methods to work correctly.

**Files Changed:**
- backend/app/schemas/professional.py: Added field_serializer
- backend/app/schemas/client.py: Added field_serializer

**Testing:**
- Backend: ruff check and format passed
- Frontend: lint, type-check, and build passed